### PR TITLE
Better genericity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rest_api_auth"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "features_lib",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "rest_api_test_helpers"
 version = "0.1.0"
 dependencies = [
@@ -2270,6 +2280,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,6 +1740,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "features_lib",
+ "signatures",
  "thiserror",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,9 +227,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
@@ -254,9 +254,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
@@ -281,7 +281,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -570,12 +570,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "fnv"
@@ -750,20 +750,20 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
  "wasm-bindgen",
 ]
 
@@ -773,7 +773,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.10.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1266,15 +1266,15 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1315,9 +1315,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libgit2-sys"
@@ -1361,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1373,9 +1373,9 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchit"
@@ -1385,9 +1385,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mime"
@@ -1402,19 +1402,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6bf96cef396a17a96f7600281aa4da9229860b7a082601b1f6db6eaa5f99ee5"
 dependencies = [
  "ct-codecs",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "rpassword",
  "scrypt",
 ]
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -1474,7 +1474,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1578,18 +1578,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -1803,15 +1803,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1838,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "zeroize",
 ]
@@ -1903,7 +1903,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2105,9 +2105,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2157,7 +2157,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.10.0",
  "core-foundation",
  "system-configuration-sys 0.6.0",
 ]
@@ -2189,7 +2189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2358,7 +2358,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -2384,9 +2384,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -2407,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -2422,15 +2422,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "untrusted"
@@ -2468,7 +2468,7 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2501,45 +2501,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2550,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2560,31 +2547,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2598,7 +2585,7 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
@@ -2627,12 +2614,6 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
@@ -2643,7 +2624,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
@@ -2654,7 +2635,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2663,7 +2644,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2699,7 +2680,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2708,7 +2689,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2744,19 +2725,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2773,9 +2754,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2791,9 +2772,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2809,9 +2790,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -2821,9 +2802,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2839,9 +2820,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2857,9 +2838,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2875,9 +2856,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2893,9 +2874,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winreg"
@@ -2908,13 +2889,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.2",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,7 +1740,6 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "features_lib",
- "signatures",
  "thiserror",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ name = "aggregate_signature"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "common",
  "minisign",
@@ -150,10 +150,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -165,7 +165,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower",
  "tower-layer",
@@ -181,16 +181,22 @@ checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -212,6 +218,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -330,9 +342,14 @@ dependencies = [
  "chrono",
  "clap",
  "features_lib",
+ "minisign",
+ "reqwest 0.11.27",
+ "rest_api_auth",
  "rpassword",
  "serde_json",
+ "signatures",
  "thiserror",
+ "uuid",
  "zxcvbn",
 ]
 
@@ -347,7 +364,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "hex",
  "minisign",
  "serde",
@@ -756,13 +773,32 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.2",
  "libc",
  "libgit2-sys",
  "log",
  "openssl-probe",
  "openssl-sys",
  "url",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -776,7 +812,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -813,6 +849,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -823,12 +870,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -839,8 +897,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -858,6 +916,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -866,9 +948,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -885,8 +967,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -897,13 +979,26 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -917,20 +1012,20 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
- "system-configuration",
+ "socket2 0.6.1",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -1379,7 +1474,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1536,21 +1631,61 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -1562,7 +1697,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tower",
@@ -1587,7 +1722,7 @@ dependencies = [
  "kameo",
  "log",
  "normalize-path",
- "reqwest",
+ "reqwest 0.12.26",
  "rest_api_test_helpers",
  "rest_api_types",
  "serde",
@@ -1672,7 +1807,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1690,6 +1825,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1759,7 +1903,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1864,7 +2008,7 @@ name = "signatures"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "common",
  "minisign",
  "serde",
@@ -1923,6 +2067,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
@@ -1962,6 +2116,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -1982,13 +2142,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.2",
  "core-foundation",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2081,7 +2262,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -2164,7 +2345,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2177,11 +2358,11 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -2487,6 +2668,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2519,6 +2709,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2556,6 +2761,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2568,6 +2779,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2577,6 +2794,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2604,6 +2827,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2613,6 +2842,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2628,6 +2863,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2637,6 +2878,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2651,12 +2898,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ members = [
   "client-cli",
   "rest-api",
   "rest_api_test_helpers",
-  "rest_api_types", "rest_api_auth",
+  "rest_api_types",
+  "rest_api_auth",
 ]
+exclude = ["rest_api_auth", "client_cli"]
 
 [workspace.lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
   "client-cli",
   "rest-api",
   "rest_api_test_helpers",
-  "rest_api_types",
+  "rest_api_types", "rest_api_auth",
 ]
 
 [workspace.lints.clippy]

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -5,13 +5,18 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.53", features = ["derive"] }
-thiserror = "2.0.17"
-anyhow = "1.0.100"
+thiserror = "2.0"
+anyhow = "1.0"
 rpassword = "7.4.0"
 features_lib = { path = "../core/features_lib/" }
 zxcvbn = "3.1.0"
 serde_json = "1.0"
 chrono = "0.4"
+rest_api_auth = { path = "../rest_api_auth/" }
+reqwest = { version = "0.11", features = ["json"] }
+uuid = { version = "1.0", features = ["v4"] }
+signatures = { version = "0.1.0", path = "../core/signatures" }
+minisign = "0.8.0"
 
 [lints]
 workspace = true

--- a/client-cli/src/commands/add_to_aggregate.rs
+++ b/client-cli/src/commands/add_to_aggregate.rs
@@ -1,7 +1,6 @@
 use crate::error::Result;
 use features_lib::sha512_for_file;
-use features_lib::{AsfaloadPublicKeys, AsfaloadSecretKeys};
-use signatures::keys::{AsfaloadPublicKeyTrait, AsfaloadSecretKeyTrait, AsfaloadSignatureTrait};
+use features_lib::{AsfaloadPublicKeys, AsfaloadSecretKeys, AsfaloadPublicKeyTrait, AsfaloadSecretKeyTrait, AsfaloadSignatureTrait};
 use std::path::Path;
 
 pub fn handle_add_to_aggregate_command<P: AsRef<Path>>(
@@ -10,7 +9,7 @@ pub fn handle_add_to_aggregate_command<P: AsRef<Path>>(
     password: &str,
 ) -> Result<()> {
     // Load the secret key
-    let secret_key = AsfaloadSecretKeys::from_file(&secret_key, password)?;
+    let secret_key = AsfaloadSecretKeys::from_file(secret_key, password)?;
 
     // Compute the AsfaloadHash of the file
     let data_to_sign = sha512_for_file(signed_file)?;

--- a/client-cli/src/commands/add_to_aggregate.rs
+++ b/client-cli/src/commands/add_to_aggregate.rs
@@ -21,11 +21,10 @@ pub fn handle_add_to_aggregate_command<P: AsRef<Path>>(
     let signature = secret_key.key.sign(&data_to_sign)?;
 
     // Derive the public key from the secret key
-    let public_key = PublicKey::from_secret_key(secret_key.key)?;
+    let public_key = PublicKey::<minisign::PublicKey>::from_secret_key(secret_key.key)?;
 
     // Add the signature to the aggregate for the file
     signature.add_to_aggregate_for_file(signed_file, &public_key)?;
 
     Ok(())
 }
-

--- a/client-cli/src/commands/add_to_aggregate.rs
+++ b/client-cli/src/commands/add_to_aggregate.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use features_lib::sha512_for_file;
-use features_lib::SignatureTrait;
-use features_lib::{PublicKey, PublicKeyTrait, SecretKey, SecretKeyTrait};
+use features_lib::{AsfaloadPublicKeys, AsfaloadSecretKeys};
+use signatures::keys::{AsfaloadPublicKeyTrait, AsfaloadSecretKeyTrait, AsfaloadSignatureTrait};
 use std::path::Path;
 
 pub fn handle_add_to_aggregate_command<P: AsRef<Path>>(
@@ -10,15 +10,15 @@ pub fn handle_add_to_aggregate_command<P: AsRef<Path>>(
     password: &str,
 ) -> Result<()> {
     // Load the secret key
-    let secret_key = SecretKey::from_file(secret_key, password)?;
+    let secret_key = AsfaloadSecretKeys::from_file(&secret_key, password)?;
 
     // Compute the AsfaloadHash of the file
     let data_to_sign = sha512_for_file(signed_file)?;
 
     // Sign the data with the secret key
-    let signature = secret_key.key.sign(&data_to_sign)?;
+    let signature = secret_key.sign(&data_to_sign)?;
 
-    let public_key = PublicKey::from_secret_key(secret_key.key)?;
+    let public_key = AsfaloadPublicKeys::from_secret_key(secret_key)?;
 
     // Add the signature to the aggregate for the file
     signature.add_to_aggregate_for_file(signed_file, &public_key)?;

--- a/client-cli/src/commands/add_to_aggregate.rs
+++ b/client-cli/src/commands/add_to_aggregate.rs
@@ -1,9 +1,7 @@
 use crate::error::Result;
 use features_lib::sha512_for_file;
-use features_lib::AsfaloadSignatureTrait;
-use features_lib::SecretKey;
-use features_lib::SecretKeyTrait;
-use features_lib::{PublicKey, PublicKeyTrait};
+use features_lib::SignatureTrait;
+use features_lib::{PublicKey, PublicKeyTrait, SecretKey, SecretKeyTrait};
 use std::path::Path;
 
 pub fn handle_add_to_aggregate_command<P: AsRef<Path>>(
@@ -20,8 +18,7 @@ pub fn handle_add_to_aggregate_command<P: AsRef<Path>>(
     // Sign the data with the secret key
     let signature = secret_key.key.sign(&data_to_sign)?;
 
-    // Derive the public key from the secret key
-    let public_key = PublicKey::<minisign::PublicKey>::from_secret_key(secret_key.key)?;
+    let public_key = PublicKey::from_secret_key(secret_key.key)?;
 
     // Add the signature to the aggregate for the file
     signature.add_to_aggregate_for_file(signed_file, &public_key)?;

--- a/client-cli/src/commands/keys.rs
+++ b/client-cli/src/commands/keys.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use crate::utils::ensure_dir_exists;
 use anyhow::Result;
-use features_lib::KeyPair;
+use features_lib::AsfaloadKeyPairs;
+use signatures::keys::AsfaloadKeyPairTrait;
 
 /// Handles the `keys` command.
 ///
@@ -20,12 +21,14 @@ pub fn handle_new_keys_command(name: &str, output_dir: &Path, password: String) 
         "Generating keypair with name '{}' in directory {:?}",
         name, output_dir
     );
-    let kp = KeyPair::new(output_dir, name, password.as_str())?;
+    let kp = AsfaloadKeyPairs::new(password.as_str())?;
+    let location = output_dir.join(name);
+    kp.save(&location)?;
 
     println!(
         "Public key saved at {}.pub and secret key at {}",
-        kp.location.to_string_lossy(),
-        kp.location.to_string_lossy()
+        location.to_string_lossy(),
+        location.to_string_lossy()
     );
     Ok(())
 }

--- a/client-cli/src/commands/keys.rs
+++ b/client-cli/src/commands/keys.rs
@@ -2,8 +2,7 @@ use std::path::Path;
 
 use crate::utils::ensure_dir_exists;
 use anyhow::Result;
-use features_lib::AsfaloadKeyPairs;
-use signatures::keys::AsfaloadKeyPairTrait;
+use features_lib::{AsfaloadKeyPairs, AsfaloadKeyPairTrait};
 
 /// Handles the `keys` command.
 ///

--- a/client-cli/src/commands/sign_file.rs
+++ b/client-cli/src/commands/sign_file.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use features_lib::sha512_for_file;
-use features_lib::{SecretKey, SecretKeyTrait};
-use features_lib::SignatureTrait;
+use features_lib::AsfaloadSecretKeys;
+use signatures::keys::{AsfaloadSecretKeyTrait, AsfaloadSignatureTrait};
 use std::path::Path;
 
 pub fn handle_sign_file_command<P: AsRef<Path>>(
@@ -10,9 +10,9 @@ pub fn handle_sign_file_command<P: AsRef<Path>>(
     password: &str,
     output_file: &P,
 ) -> Result<()> {
-    let secret_key = SecretKey::from_file(secret_key, password)?;
+    let secret_key = AsfaloadSecretKeys::from_file(&secret_key, password)?;
     let data_to_sign = sha512_for_file(file_to_sign)?;
-    let signature = secret_key.key.sign(&data_to_sign)?;
+    let signature = secret_key.sign(&data_to_sign)?;
     signature.to_file(output_file)?;
     Ok(())
 }

--- a/client-cli/src/commands/sign_file.rs
+++ b/client-cli/src/commands/sign_file.rs
@@ -1,8 +1,7 @@
 use crate::error::Result;
 use features_lib::sha512_for_file;
-use features_lib::AsfaloadSignatureTrait;
-use features_lib::SecretKey;
-use features_lib::SecretKeyTrait;
+use features_lib::{SecretKey, SecretKeyTrait};
+use features_lib::SignatureTrait;
 use std::path::Path;
 
 pub fn handle_sign_file_command<P: AsRef<Path>>(

--- a/client-cli/src/commands/sign_file.rs
+++ b/client-cli/src/commands/sign_file.rs
@@ -1,7 +1,6 @@
 use crate::error::Result;
 use features_lib::sha512_for_file;
-use features_lib::AsfaloadSecretKeys;
-use signatures::keys::{AsfaloadSecretKeyTrait, AsfaloadSignatureTrait};
+use features_lib::{AsfaloadSecretKeys, AsfaloadSecretKeyTrait, AsfaloadSignatureTrait};
 use std::path::Path;
 
 pub fn handle_sign_file_command<P: AsRef<Path>>(

--- a/client-cli/src/commands/signers_file.rs
+++ b/client-cli/src/commands/signers_file.rs
@@ -4,8 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{ClientCliError, Result};
 use crate::utils::{ensure_dir_exists, validate_threshold};
-use features_lib::{AsfaloadPublicKeys, SignersConfig};
-use signatures::keys::AsfaloadPublicKeyTrait;
+use features_lib::{AsfaloadPublicKeys, SignersConfig, AsfaloadPublicKeyTrait};
 
 fn get_group_info<P: AsfaloadPublicKeyTrait>(
     keys: Vec<P>,

--- a/client-cli/src/commands/signers_file.rs
+++ b/client-cli/src/commands/signers_file.rs
@@ -4,11 +4,10 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{ClientCliError, Result};
 use crate::utils::{ensure_dir_exists, validate_threshold};
-use features_lib::PublicKey;
-use features_lib::PublicKeyTrait;
-use features_lib::SignersConfig;
+use features_lib::{AsfaloadPublicKeys, SignersConfig};
+use signatures::keys::AsfaloadPublicKeyTrait;
 
-fn get_group_info<P: PublicKeyTrait>(
+fn get_group_info<P: AsfaloadPublicKeyTrait>(
     keys: Vec<P>,
     threshold: Option<u32>,
 ) -> std::result::Result<Option<(Vec<P>, u32)>, ClientCliError> {
@@ -74,7 +73,7 @@ pub fn handle_new_signers_file_command(
     }
 
     // Combine string and file-based artifact signers
-    let all_artifact_signers: Vec<PublicKey> =
+    let all_artifact_signers: Vec<AsfaloadPublicKeys> =
         combine_key_sources(artifact_signer, artifact_signer_file)?;
     let all_artifact_signers_count = all_artifact_signers.len();
 
@@ -87,12 +86,12 @@ pub fn handle_new_signers_file_command(
     validate_threshold(artifact_threshold, all_artifact_signers.len())?;
 
     // Combine string and file-based admin keys
-    let all_admin_keys = combine_key_sources(admin_key, admin_key_file)?;
+    let all_admin_keys: Vec<AsfaloadPublicKeys> = combine_key_sources(admin_key, admin_key_file)?;
     let all_admin_keys_count = all_admin_keys.len();
     let admin_group_info = get_group_info(all_admin_keys, admin_threshold)?;
 
     // Combine string and file-based master keys
-    let all_master_keys = combine_key_sources(master_key, master_key_file)?;
+    let all_master_keys: Vec<AsfaloadPublicKeys> = combine_key_sources(master_key, master_key_file)?;
     let all_master_keys_count = all_master_keys.len();
     let master_group_info = get_group_info(all_master_keys, master_threshold)?;
     //
@@ -144,7 +143,7 @@ pub fn handle_new_signers_file_command(
 }
 
 /// Combine string-based keys and file-based keys into a single Vec of strings
-fn combine_key_sources<P: PublicKeyTrait>(
+fn combine_key_sources<P: AsfaloadPublicKeyTrait>(
     string_keys: &[String],
     file_keys: &[PathBuf],
 ) -> Result<Vec<P>> {

--- a/client-cli/src/commands/signers_file.rs
+++ b/client-cli/src/commands/signers_file.rs
@@ -74,7 +74,7 @@ pub fn handle_new_signers_file_command(
     }
 
     // Combine string and file-based artifact signers
-    let all_artifact_signers: Vec<PublicKey<_>> =
+    let all_artifact_signers: Vec<PublicKey> =
         combine_key_sources(artifact_signer, artifact_signer_file)?;
     let all_artifact_signers_count = all_artifact_signers.len();
 

--- a/client-cli/src/commands/verify_sig.rs
+++ b/client-cli/src/commands/verify_sig.rs
@@ -2,8 +2,7 @@ use std::path::Path;
 
 use crate::error::Result;
 use features_lib::sha512_for_file;
-use features_lib::{AsfaloadPublicKeys, AsfaloadSignatures};
-use signatures::keys::{AsfaloadPublicKeyTrait, AsfaloadSignatureTrait};
+use features_lib::{AsfaloadPublicKeys, AsfaloadSignatures, AsfaloadPublicKeyTrait, AsfaloadSignatureTrait};
 
 pub fn handle_verify_sig_command<P: AsRef<Path>>(
     signed_file: &P,

--- a/client-cli/src/commands/verify_sig.rs
+++ b/client-cli/src/commands/verify_sig.rs
@@ -2,7 +2,8 @@ use std::path::Path;
 
 use crate::error::Result;
 use features_lib::sha512_for_file;
-use features_lib::{PublicKey, PublicKeyTrait, Signature, SignatureTrait};
+use features_lib::{AsfaloadPublicKeys, AsfaloadSignatures};
+use signatures::keys::{AsfaloadPublicKeyTrait, AsfaloadSignatureTrait};
 
 pub fn handle_verify_sig_command<P: AsRef<Path>>(
     signed_file: &P,
@@ -10,10 +11,10 @@ pub fn handle_verify_sig_command<P: AsRef<Path>>(
     public_key_file: &P,
 ) -> Result<()> {
     // Load the public key
-    let public_key = PublicKey::from_file(public_key_file)?;
+    let public_key = AsfaloadPublicKeys::from_file(public_key_file)?;
 
     // Load the signature
-    let signature = Signature::from_file(signature_file)?;
+    let signature = AsfaloadSignatures::from_file(signature_file)?;
 
     // Compute the hash of the signed file
     let data_to_verify = sha512_for_file(signed_file)?;

--- a/client-cli/src/error.rs
+++ b/client-cli/src/error.rs
@@ -39,6 +39,9 @@ pub enum ClientCliError {
 
     #[error("Signers file error: {0}")]
     SignersFile(String),
+
+    #[error("Authentication error: {0}")]
+    AuthError(String),
 }
 
 pub type Result<T> = std::result::Result<T, ClientCliError>;

--- a/client-cli/src/error.rs
+++ b/client-cli/src/error.rs
@@ -41,7 +41,11 @@ pub enum ClientCliError {
     SignersFile(String),
 
     #[error("Authentication error: {0}")]
-    AuthError(String),
+    AuthError(#[from] rest_api_auth::AuthError),
+
+    #[error("Reqwest header error: {0}")]
+    ReqwestHeaderError(#[from] reqwest::header::InvalidHeaderValue),
 }
 
+// FIXME: remove this, creates more confusion than necessary
 pub type Result<T> = std::result::Result<T, ClientCliError>;

--- a/client-cli/src/rest_client.rs
+++ b/client-cli/src/rest_client.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use crate::utils::create_auth_headers;
-use features_lib::{SecretKey, SecretKeyTrait};
+use features_lib::AsfaloadSecretKeys;
 use reqwest::Client;
 use serde_json::Value;
 
@@ -36,16 +36,12 @@ impl RestClient {
     ///
     /// The response from the API
     ///
-    pub async fn post_authenticated<M>(
+    pub async fn post_authenticated(
         &self,
         endpoint: &str,
         payload: &Value,
-        secret_key: SecretKey<M>,
-    ) -> Result<Value>
-    where
-        SecretKey<M>: SecretKeyTrait<SecretKey = M>,
-        M: Clone,
-    {
+        secret_key: AsfaloadSecretKeys,
+    ) -> Result<Value> {
         // Convert payload to string
         let payload_string = payload.to_string();
 
@@ -79,4 +75,3 @@ impl RestClient {
         Ok(response_json)
     }
 }
-

--- a/client-cli/src/rest_client.rs
+++ b/client-cli/src/rest_client.rs
@@ -1,0 +1,82 @@
+use crate::error::Result;
+use crate::utils::create_auth_headers;
+use features_lib::{SecretKey, SecretKeyTrait};
+use reqwest::Client;
+use serde_json::Value;
+
+/// A client for interacting with the REST API with authentication
+pub struct RestClient {
+    client: Client,
+    base_url: String,
+}
+
+impl RestClient {
+    /// Create a new REST client
+    ///
+    /// # Arguments
+    ///
+    /// * `base_url` - The base URL of the REST API server
+    ///
+    pub fn new(base_url: String) -> Self {
+        RestClient {
+            client: Client::new(),
+            base_url,
+        }
+    }
+
+    /// Send an authenticated POST request to the API
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint` - The API endpoint (e.g., "add-file")
+    /// * `payload` - The JSON payload to send
+    /// * `secret_key` - The secret key for authentication
+    ///
+    /// # Returns
+    ///
+    /// The response from the API
+    ///
+    pub async fn post_authenticated<M>(
+        &self,
+        endpoint: &str,
+        payload: &Value,
+        secret_key: SecretKey<M>,
+    ) -> Result<Value>
+    where
+        SecretKey<M>: SecretKeyTrait<SecretKey = M>,
+        M: Clone,
+    {
+        // Convert payload to string
+        let payload_string = payload.to_string();
+
+        // Create authentication headers
+        let headers = create_auth_headers(&payload_string, secret_key)?;
+
+        // Send the request
+        let response = self
+            .client
+            .post(format!("{}/{}", self.base_url, endpoint))
+            .headers(headers)
+            .json(payload)
+            .send()
+            .await
+            .map_err(|e| crate::error::ClientCliError::AuthError(e.to_string()))?;
+
+        // Check if the request was successful
+        if !response.status().is_success() {
+            return Err(crate::error::ClientCliError::AuthError(format!(
+                "API request failed with status: {}",
+                response.status()
+            )));
+        }
+
+        // Parse and return the response
+        let response_json = response
+            .json::<Value>()
+            .await
+            .map_err(|e| crate::error::ClientCliError::AuthError(e.to_string()))?;
+
+        Ok(response_json)
+    }
+}
+

--- a/client-cli/src/utils.rs
+++ b/client-cli/src/utils.rs
@@ -177,8 +177,7 @@ pub fn create_auth_headers(payload: &str, secret_key: AsfaloadSecretKeys) -> Res
 
     // Create authentication signature
     // Now SecretKey implements SecretKeyTrait, so it should work directly
-    let auth_signature = AuthSignature::new(auth_info, secret_key)
-        .map_err(|e| ClientCliError::AuthError(e.to_string()))?;
+    let auth_signature = AuthSignature::new(auth_info, secret_key)?;
 
     // Create headers
     let mut headers = HeaderMap::new();
@@ -186,29 +185,25 @@ pub fn create_auth_headers(payload: &str, secret_key: AsfaloadSecretKeys) -> Res
     // Add timestamp header
     headers.insert(
         "X-asfld-timestamp",
-        HeaderValue::from_str(&auth_signature.auth_info().timestamp().to_rfc3339())
-            .map_err(|e| ClientCliError::AuthError(e.to_string()))?,
+        HeaderValue::from_str(&auth_signature.auth_info().timestamp().to_rfc3339())?,
     );
 
     // Add nonce header
     headers.insert(
         "X-asfld-nonce",
-        HeaderValue::from_str(&auth_signature.auth_info().nonce())
-            .map_err(|e| ClientCliError::AuthError(e.to_string()))?,
+        HeaderValue::from_str(&auth_signature.auth_info().nonce())?,
     );
 
     // Add signature header
     headers.insert(
         "X-asfld-sig",
-        HeaderValue::from_str(&auth_signature.signature().to_base64())
-            .map_err(|e| ClientCliError::AuthError(e.to_string()))?,
+        HeaderValue::from_str(&auth_signature.signature().to_base64())?,
     );
 
     // Add public key header
     headers.insert(
         "X-asfld-pk",
-        HeaderValue::from_str(&auth_signature.public_key())
-            .map_err(|e| ClientCliError::AuthError(e.to_string()))?,
+        HeaderValue::from_str(&auth_signature.public_key())?,
     );
 
     Ok(headers)

--- a/client-cli/src/utils.rs
+++ b/client-cli/src/utils.rs
@@ -4,9 +4,10 @@ use zxcvbn::{zxcvbn, Score};
 use ClientCliError::PasswordStrengthError;
 
 use crate::error::{ClientCliError, Result};
-use features_lib::{SecretKey, SignatureTrait};
+use features_lib::AsfaloadSecretKeys;
 use reqwest::header::{HeaderMap, HeaderValue};
 use rest_api_auth::AuthSignature;
+use signatures::keys::AsfaloadSignatureTrait;
 
 /// Ensures a directory exists, creating it if necessary
 pub fn ensure_dir_exists(path: &Path) -> Result<()> {
@@ -169,7 +170,7 @@ pub fn get_password(
 /// - X-asfld-nonce: UUID v4
 /// - X-asfld-sig: Signature of the auth info
 /// - X-asfld-pk: Public key in base64
-pub fn create_auth_headers(payload: &str, secret_key: SecretKey) -> Result<HeaderMap> {
+pub fn create_auth_headers(payload: &str, secret_key: AsfaloadSecretKeys) -> Result<HeaderMap> {
     use rest_api_auth::AuthInfo;
 
     // Create authentication info

--- a/client-cli/src/utils.rs
+++ b/client-cli/src/utils.rs
@@ -4,7 +4,7 @@ use zxcvbn::{zxcvbn, Score};
 use ClientCliError::PasswordStrengthError;
 
 use crate::error::{ClientCliError, Result};
-use features_lib::{SecretKey, SecretKeyTrait, SignatureTrait};
+use features_lib::{SecretKey, SignatureTrait};
 use reqwest::header::{HeaderMap, HeaderValue};
 use rest_api_auth::AuthSignature;
 
@@ -169,11 +169,7 @@ pub fn get_password(
 /// - X-asfld-nonce: UUID v4
 /// - X-asfld-sig: Signature of the auth info
 /// - X-asfld-pk: Public key in base64
-pub fn create_auth_headers<MSK>(payload: &str, secret_key: SecretKey<MSK>) -> Result<HeaderMap>
-where
-    SecretKey<MSK>: SecretKeyTrait<SecretKey = MSK>,
-    MSK: Clone,
-{
+pub fn create_auth_headers(payload: &str, secret_key: SecretKey) -> Result<HeaderMap> {
     use rest_api_auth::AuthInfo;
 
     // Create authentication info
@@ -181,7 +177,6 @@ where
 
     // Create authentication signature
     // Now SecretKey implements SecretKeyTrait, so it should work directly
-    // We need to specify the type parameters for AuthSignature
     let auth_signature = AuthSignature::new(auth_info, secret_key)
         .map_err(|e| ClientCliError::AuthError(e.to_string()))?;
 

--- a/client-cli/src/utils.rs
+++ b/client-cli/src/utils.rs
@@ -4,10 +4,9 @@ use zxcvbn::{zxcvbn, Score};
 use ClientCliError::PasswordStrengthError;
 
 use crate::error::{ClientCliError, Result};
-use features_lib::AsfaloadSecretKeys;
+use features_lib::{AsfaloadSecretKeys, AsfaloadSignatureTrait};
 use reqwest::header::{HeaderMap, HeaderValue};
 use rest_api_auth::AuthSignature;
-use signatures::keys::AsfaloadSignatureTrait;
 
 /// Ensures a directory exists, creating it if necessary
 pub fn ensure_dir_exists(path: &Path) -> Result<()> {

--- a/core/features_lib/src/lib.rs
+++ b/core/features_lib/src/lib.rs
@@ -13,41 +13,40 @@ use common::{
 
 pub use common::{AsfaloadHashes, sha512_for_content, sha512_for_file};
 
+use signatures::keys::minisign;
 use signatures::keys::{
-    AsfaloadKeyPairTrait, AsfaloadPublicKey, AsfaloadPublicKeyTrait, AsfaloadSecretKey,
-    AsfaloadSignature,
+    AsfaloadKeyPairTrait, AsfaloadPublicKeyTrait, AsfaloadSecretKeyTrait, AsfaloadSignatureTrait,
+};
+use signatures::types::{
+    AsfaloadKeyPairs, AsfaloadPublicKeys, AsfaloadSecretKeys, AsfaloadSignatures,
 };
 
-pub use signatures::keys::AsfaloadPublicKey as PublicKey;
 pub use signatures::keys::AsfaloadPublicKeyTrait as PublicKeyTrait;
 pub use signatures::keys::AsfaloadSecretKeyTrait as SecretKeyTrait;
-pub use signatures::keys::AsfaloadSignature as Signature;
 pub use signatures::keys::AsfaloadSignatureTrait as SignatureTrait;
+pub use signatures::types::AsfaloadPublicKeys as PublicKey;
+pub use signatures::types::AsfaloadSecretKeys as SecretKeyType;
+pub use signatures::types::AsfaloadSignatures as Signature;
 
+use signers_file::sign_signers_file;
 pub use signers_file_types::SignersConfig;
 
-use signatures::keys::AsfaloadKeyPair;
-pub use signatures::keys::AsfaloadSignatureTrait;
-use signers_file::sign_signers_file;
-
-// In this type argument we constrain the type argument of the SignatureWithState type
-// to AsfaloadPublicKey and AsfaloadSignature. Doing this allows the user of this
-// type to not specify the type arguments, makeing the code more succint.
-pub type SignatureWithState<MP, MS> =
-    aggregate_signature::SignatureWithState<AsfaloadPublicKey<MP>, AsfaloadSignature<MS>>;
+// In this type argument we use AsfaloadPublicKeys and AsfaloadSignatures directly.
+// This allows the user of this type to not specify any type arguments.
+pub type SignatureWithState = aggregate_signature::SignatureWithState;
 
 // We define and implement this trait in the user_lib as it depends on traits defined in other crates,
 // which we want to avoid in common.
-pub trait SignedFileTrait<MP, MS>
+pub trait SignedFileTrait
 where
-    AsfaloadPublicKey<MP>: AsfaloadPublicKeyTrait<Signature = AsfaloadSignature<MS>>,
-    AsfaloadSignature<MS>: AsfaloadSignatureTrait,
+    AsfaloadPublicKeys: AsfaloadPublicKeyTrait<Signature = AsfaloadSignatures>,
+    AsfaloadSignatures: AsfaloadSignatureTrait,
 {
     fn add_signature(
         &self,
-        sig: AsfaloadSignature<MS>,
-        pubkey: AsfaloadPublicKey<MP>,
-    ) -> Result<SignatureWithState<MP, MS>, SignedFileError>;
+        sig: AsfaloadSignatures,
+        pubkey: AsfaloadPublicKeys,
+    ) -> Result<SignatureWithState, SignedFileError>;
     fn is_signed(&self) -> Result<bool, SignedFileError>;
 }
 
@@ -60,43 +59,39 @@ pub trait SignableFileMarker {}
 impl SignableFileMarker for InitialSignersFileMarker {}
 impl SignableFileMarker for SignersFileMarker {}
 
-impl<MP, MS, T> SignedFileTrait<MP, MS> for SignedFile<T>
+impl<T> SignedFileTrait for SignedFile<T>
 where
     T: SignableFileMarker,
-    MP: Clone,
-    MS: Clone,
-    AsfaloadPublicKey<MP>: AsfaloadPublicKeyTrait<Signature = AsfaloadSignature<MS>>,
-    AsfaloadSignature<MS>: AsfaloadSignatureTrait,
+    AsfaloadPublicKeys: AsfaloadPublicKeyTrait<Signature = AsfaloadSignatures>,
+    AsfaloadSignatures: AsfaloadSignatureTrait,
 {
     fn add_signature(
         &self,
-        sig: AsfaloadSignature<MS>,
-        pubkey: AsfaloadPublicKey<MP>,
-    ) -> Result<SignatureWithState<MP, MS>, SignedFileError> {
+        sig: AsfaloadSignatures,
+        pubkey: AsfaloadPublicKeys,
+    ) -> Result<SignatureWithState, SignedFileError> {
         sign_signers_file(&self.location, &sig, &pubkey).map_err(|e| e.into())
     }
 
     fn is_signed(&self) -> Result<bool, SignedFileError> {
-        let r = SignatureWithState::<MP, MS>::load_for_file(&self.location)?
+        let r = SignatureWithState::load_for_file(&self.location)?
             .get_complete()
             .is_some();
         Ok(r)
     }
 }
 
-impl<MP, MS> SignedFileTrait<MP, MS> for SignedFile<ArtifactMarker>
+impl SignedFileTrait for SignedFile<ArtifactMarker>
 where
-    MP: Clone,
-    MS: Clone,
-    AsfaloadPublicKey<MP>: AsfaloadPublicKeyTrait<Signature = AsfaloadSignature<MS>>,
-    AsfaloadSignature<MS>: AsfaloadSignatureTrait,
+    AsfaloadPublicKeys: AsfaloadPublicKeyTrait<Signature = AsfaloadSignatures>,
+    AsfaloadSignatures: AsfaloadSignatureTrait,
 {
     fn add_signature(
         &self,
-        sig: AsfaloadSignature<MS>,
-        pubkey: AsfaloadPublicKey<MP>,
-    ) -> Result<SignatureWithState<MP, MS>, SignedFileError> {
-        let agg_sig_with_state = SignatureWithState::<MP, MS>::load_for_file(&self.location)?;
+        sig: AsfaloadSignatures,
+        pubkey: AsfaloadPublicKeys,
+    ) -> Result<SignatureWithState, SignedFileError> {
+        let agg_sig_with_state = SignatureWithState::load_for_file(&self.location)?;
         if let Some(pending_sig) = agg_sig_with_state.get_pending() {
             pending_sig
                 .add_individual_signature(&sig, &pubkey)
@@ -118,33 +113,29 @@ where
     }
 }
 
-pub trait SignedFileWithKindTrait<MP, MS>
+pub trait SignedFileWithKindTrait
 where
-    MP: Clone,
-    MS: Clone,
-    AsfaloadPublicKey<MP>: AsfaloadPublicKeyTrait<Signature = AsfaloadSignature<MS>>,
-    AsfaloadSignature<MS>: AsfaloadSignatureTrait,
+    AsfaloadPublicKeys: AsfaloadPublicKeyTrait<Signature = AsfaloadSignatures>,
+    AsfaloadSignatures: AsfaloadSignatureTrait,
 {
     fn add_signature(
         &self,
-        sig: AsfaloadSignature<MS>,
-        pubkey: AsfaloadPublicKey<MP>,
-    ) -> Result<SignatureWithState<MP, MS>, SignedFileError>;
+        sig: AsfaloadSignatures,
+        pubkey: AsfaloadPublicKeys,
+    ) -> Result<SignatureWithState, SignedFileError>;
     fn is_signed(&self) -> Result<bool, SignedFileError>;
 }
 
-impl<MP, MS> SignedFileWithKindTrait<MP, MS> for SignedFileWithKind
+impl SignedFileWithKindTrait for SignedFileWithKind
 where
-    MP: Clone,
-    MS: Clone,
-    AsfaloadPublicKey<MP>: AsfaloadPublicKeyTrait<Signature = AsfaloadSignature<MS>>,
-    AsfaloadSignature<MS>: AsfaloadSignatureTrait,
+    AsfaloadPublicKeys: AsfaloadPublicKeyTrait<Signature = AsfaloadSignatures>,
+    AsfaloadSignatures: AsfaloadSignatureTrait,
 {
     fn add_signature(
         &self,
-        sig: AsfaloadSignature<MS>,
-        pubkey: AsfaloadPublicKey<MP>,
-    ) -> Result<SignatureWithState<MP, MS>, SignedFileError> {
+        sig: AsfaloadSignatures,
+        pubkey: AsfaloadPublicKeys,
+    ) -> Result<SignatureWithState, SignedFileError> {
         match self {
             SignedFileWithKind::InitialSignersFile(sf) => sf.add_signature(sig, pubkey),
             SignedFileWithKind::SignersFile(sf) => sf.add_signature(sig, pubkey),
@@ -176,35 +167,27 @@ impl SignersFileTrait for SignersFile {
     }
 }
 
-pub struct KeyPair<M> {
+pub struct KeyPair {
     pub location: PathBuf,
-    pub keypair: AsfaloadKeyPair<M>,
+    pub keypair: AsfaloadKeyPairs,
 }
-impl<M> KeyPair<M>
-where
-    // This Higher-Rank Trait Bound states that AsfaloadKeyPair<M> must implement
-    // AsfaloadKeyPairTrait for *any* lifetime 'a.
-    AsfaloadKeyPair<M>: for<'a> AsfaloadKeyPairTrait<'a>,
-{
+impl KeyPair {
     pub fn new<P: AsRef<Path>>(dir: P, name: &str, password: &str) -> Result<Self, KeyError> {
-        let keypair = AsfaloadKeyPair::new(password)?;
+        let keypair = AsfaloadKeyPairs::new(password)?;
         let location = dir.as_ref().join(name);
         keypair.save(&location)?;
-        Ok(KeyPair::<M> { keypair, location })
+        Ok(KeyPair { keypair, location })
     }
 }
 
-pub struct SecretKey<M> {
+pub struct SecretKey {
     pub location: PathBuf,
-    pub key: AsfaloadSecretKey<M>,
+    pub key: AsfaloadSecretKeys,
 }
-impl<M> SecretKey<M>
-where
-    AsfaloadSecretKey<M>: SecretKeyTrait,
-{
+impl SecretKey {
     pub fn from_file<P: AsRef<Path>>(location: P, password: &str) -> Result<Self, KeyError> {
-        let key = AsfaloadSecretKey::from_file(&location, password)?;
-        Ok(SecretKey::<M> {
+        let key = AsfaloadSecretKeys::from_file(&location, password)?;
+        Ok(SecretKey {
             key,
             location: location.as_ref().to_path_buf(),
         })
@@ -212,12 +195,9 @@ where
 }
 
 // Implement SecretKeyTrait for SecretKey to make it compatible with AuthSignature::new
-impl<M> SecretKeyTrait for SecretKey<M>
-where
-    AsfaloadSecretKey<M>: SecretKeyTrait,
-{
-    type SecretKey = M;
-    type Signature = <AsfaloadSecretKey<M> as SecretKeyTrait>::Signature;
+impl SecretKeyTrait for SecretKey {
+    type SecretKey = minisign::SecretKey;
+    type Signature = AsfaloadSignatures;
 
     fn sign(&self, data: &AsfaloadHashes) -> Result<Self::Signature, SignError> {
         self.key.sign(data)
@@ -227,7 +207,7 @@ where
     where
         Self: Sized,
     {
-        let key = AsfaloadSecretKey::from_bytes(data)?;
+        let key = AsfaloadSecretKeys::from_bytes(data)?;
         Ok(SecretKey {
             key,
             location: PathBuf::new(), // Default location for bytes-based creation
@@ -238,7 +218,7 @@ where
     where
         Self: Sized,
     {
-        let key = AsfaloadSecretKey::from_string(s)?;
+        let key = AsfaloadSecretKeys::from_string(s)?;
         Ok(SecretKey {
             key,
             location: PathBuf::new(), // Default location for string-based creation
@@ -250,7 +230,7 @@ where
         Self: Sized,
     {
         let path_ref = path.as_ref();
-        let key = AsfaloadSecretKey::from_file(path_ref, password)?;
+        let key = AsfaloadSecretKeys::from_file(path_ref, password)?;
         Ok(SecretKey {
             key,
             location: path_ref.to_path_buf(),
@@ -264,19 +244,16 @@ pub mod aggregate_signature_helpers {
     use aggregate_signature::get_individual_signatures as get_individual_signatures_ori;
     pub use aggregate_signature::{check_groups, load_signers_config};
     use common::errors::AggregateSignatureError;
-    use signatures::keys::{
-        AsfaloadPublicKey, AsfaloadPublicKeyTrait, AsfaloadSignature, AsfaloadSignatureTrait,
-    };
+    use signatures::keys::{AsfaloadPublicKeyTrait, AsfaloadSignatureTrait};
+    use signatures::types::{AsfaloadPublicKeys, AsfaloadSignatures};
 
-    pub fn get_individual_signatures<P: AsRef<Path>, MP: Clone, MS: Clone>(
+    pub fn get_individual_signatures<P: AsRef<Path>>(
         sig_file_path: P,
-    ) -> Result<HashMap<AsfaloadPublicKey<MP>, AsfaloadSignature<MS>>, AggregateSignatureError>
+    ) -> Result<HashMap<AsfaloadPublicKeys, AsfaloadSignatures>, AggregateSignatureError>
     where
-        AsfaloadPublicKey<MP>: AsfaloadPublicKeyTrait<Signature = AsfaloadSignature<MS>>,
-        AsfaloadSignature<MS>: AsfaloadSignatureTrait,
+        AsfaloadPublicKeys: AsfaloadPublicKeyTrait<Signature = AsfaloadSignatures>,
+        AsfaloadSignatures: AsfaloadSignatureTrait,
     {
-        get_individual_signatures_ori::<AsfaloadPublicKey<MP>, AsfaloadSignature<MS>, _>(
-            sig_file_path,
-        )
+        get_individual_signatures_ori::<AsfaloadPublicKeys, AsfaloadSignatures, _>(sig_file_path)
     }
 }

--- a/core/features_lib/src/lib.rs
+++ b/core/features_lib/src/lib.rs
@@ -12,8 +12,11 @@ use common::{
 
 pub use common::{AsfaloadHashes, sha512_for_content, sha512_for_file};
 
-// Import traits needed for trait bounds
-use signatures::keys::{AsfaloadPublicKeyTrait, AsfaloadSignatureTrait};
+// Re-export traits for users
+pub use signatures::keys::AsfaloadKeyPairTrait;
+pub use signatures::keys::AsfaloadPublicKeyTrait;
+pub use signatures::keys::AsfaloadSecretKeyTrait;
+pub use signatures::keys::AsfaloadSignatureTrait;
 
 // Re-export the types directly
 pub use signatures::types::AsfaloadKeyPairs;

--- a/core/signatures/src/keys.rs
+++ b/core/signatures/src/keys.rs
@@ -11,10 +11,6 @@ pub enum KeyFormat {
     Minisign,
 }
 
-pub enum AsfaloadKeyPairs {
-    Minisign(minisign::KeyPair),
-}
-
 // Trait that we will implement for keypairs we support. Initially only minisign::KeyPair
 pub trait AsfaloadKeyPairTrait<'a>: Sized {
     type PublicKey;
@@ -55,6 +51,7 @@ pub trait AsfaloadSecretKeyTrait: Sized {
 
 // Struct to store a secret key immediately usable.
 // This means that for minisign, it holds the non-encrypted secret key.
+#[derive(Debug)]
 pub struct AsfaloadSecretKey<K> {
     // Keep it private as for minisign it is the decrypted key, i.e. non password protected.
     key: K,
@@ -79,7 +76,7 @@ pub trait AsfaloadPublicKeyTrait: Sized + Eq + std::hash::Hash + Clone + std::fm
         Self::from_bytes(&s.into_bytes())
     }
     fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, KeyError>;
-    fn from_secret_key(sk: AsfaloadSecretKey<Self::SecretKeyType>) -> Result<Self, KeyError>;
+    fn from_secret_key(sk: Self::SecretKeyType) -> Result<Self, KeyError>;
     fn key_format(&self) -> KeyFormat;
     fn key(&self) -> Self::KeyType;
 }

--- a/core/signatures/src/keys/minisign.rs
+++ b/core/signatures/src/keys/minisign.rs
@@ -9,7 +9,7 @@ use common::{
     errors::keys::*,
     fs::names::{pending_signatures_path_for, signatures_path_for},
 };
-pub use minisign::{KeyPair, PublicKey};
+pub use minisign::{KeyPair, PublicKey, SecretKey, SignatureBox};
 use serde_json;
 use std::{
     ffi::OsString,
@@ -132,7 +132,7 @@ impl AsfaloadSecretKeyTrait for AsfaloadSecretKey<minisign::SecretKey> {
 impl AsfaloadPublicKeyTrait for AsfaloadPublicKey<minisign::PublicKey> {
     type Signature = AsfaloadSignature<minisign::SignatureBox>;
     type KeyType = minisign::PublicKey;
-    type SecretKeyType = minisign::SecretKey;
+    type SecretKeyType = AsfaloadSecretKey<minisign::SecretKey>;
 
     fn verify(
         &self,
@@ -174,7 +174,7 @@ impl AsfaloadPublicKeyTrait for AsfaloadPublicKey<minisign::PublicKey> {
         Ok(AsfaloadPublicKey { key: k })
     }
 
-    fn from_secret_key(sk: AsfaloadSecretKey<Self::SecretKeyType>) -> Result<Self, KeyError> {
+    fn from_secret_key(sk: Self::SecretKeyType) -> Result<Self, KeyError> {
         let k = PublicKey::from_secret_key(&sk.key)?;
         Ok(AsfaloadPublicKey { key: k })
     }

--- a/core/signatures/src/lib.rs
+++ b/core/signatures/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod keys;
+pub mod types;

--- a/core/signatures/src/types.rs
+++ b/core/signatures/src/types.rs
@@ -1,0 +1,267 @@
+// We defined here enum types implementing the Asfaload traits allowing to support mulitple signing
+// algorithms. We have one enum per crypo element (public key, secret key, signature, keypair) and
+// each enum hase one case per algorithm we support.
+// These enum simply wrap the corresponding Asfaload type (eg AsfaloadPublicKey<_>), setting its
+// generic type, and implement the same traits, delegating the action of the trait's functions to
+// the wrapped value. For example, AsfaloadPublicKeys has one case Minisign which wrap
+// AsfaloadPublicKey<minisign::PublicKey>. It implements AsfaloadPublicKeyTrait.
+
+use crate::keys::{
+    AsfaloadKeyPair, AsfaloadKeyPairTrait, AsfaloadPublicKey, AsfaloadPublicKeyTrait,
+    AsfaloadSecretKey, AsfaloadSecretKeyTrait, AsfaloadSignature, AsfaloadSignatureTrait,
+    KeyFormat,
+};
+use common::fs::names::{pending_signatures_path_for, signatures_path_for};
+use common::{
+    AsfaloadHashes,
+    errors::keys::{KeyError, SignError, SignatureError, VerifyError},
+};
+use std::fs::File;
+use std::path::Path;
+
+#[cfg(test)]
+mod tests;
+
+pub enum AsfaloadKeyPairs {
+    Minisign(AsfaloadKeyPair<minisign::KeyPair>),
+}
+impl<'a> AsfaloadKeyPairTrait<'a> for AsfaloadKeyPairs {
+    type PublicKey = AsfaloadPublicKeys;
+    type SecretKey = AsfaloadSecretKeys;
+    fn new(pw: &str) -> Result<Self, common::errors::keys::KeyError> {
+        let minisign_key = AsfaloadKeyPair::<minisign::KeyPair>::new(pw)?;
+        Ok(Self::Minisign(minisign_key))
+    }
+    fn save<T: AsRef<std::path::Path>>(
+        &self,
+        p: T,
+    ) -> Result<&Self, common::errors::keys::KeyError> {
+        match self {
+            Self::Minisign(kp) => kp.save(p)?,
+        };
+        Ok(self)
+    }
+
+    fn secret_key(
+        &self,
+        password: &str,
+    ) -> Result<Self::SecretKey, common::errors::keys::KeyError> {
+        match self {
+            Self::Minisign(kp) => Ok(AsfaloadSecretKeys::Minisign(kp.secret_key(password)?)),
+        }
+    }
+
+    fn public_key(&self) -> Self::PublicKey {
+        match self {
+            Self::Minisign(kp) => AsfaloadPublicKeys::Minisign(kp.public_key()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AsfaloadPublicKeys {
+    Minisign(AsfaloadPublicKey<minisign::PublicKey>),
+}
+
+impl AsfaloadPublicKeyTrait for AsfaloadPublicKeys {
+    type Signature = AsfaloadSignatures;
+    type KeyType = AsfaloadPublicKeys;
+    type SecretKeyType = AsfaloadSecretKeys;
+
+    fn verify(
+        &self,
+        signature: &Self::Signature,
+        data: &AsfaloadHashes,
+    ) -> Result<(), VerifyError> {
+        match (self, signature) {
+            (Self::Minisign(pk), AsfaloadSignatures::Minisign(sig)) => pk.verify(sig, data),
+        }
+    }
+
+    fn to_base64(&self) -> String {
+        match self {
+            Self::Minisign(pk) => pk.to_base64(),
+        }
+    }
+
+    fn from_bytes(data: &[u8]) -> Result<Self, KeyError> {
+        let pk = AsfaloadPublicKey::<minisign::PublicKey>::from_bytes(data)?;
+        Ok(Self::Minisign(pk))
+    }
+
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, KeyError> {
+        let pk = AsfaloadPublicKey::<minisign::PublicKey>::from_file(path)?;
+        Ok(Self::Minisign(pk))
+    }
+
+    fn from_base64(s: String) -> Result<Self, KeyError> {
+        // With multiple backing algorithms, we could try one
+        // after the other and return the corresponding one
+        // if only one worked. If multiple attempts are successful
+        // we don't know which one should be returned.
+        let pk = AsfaloadPublicKey::<minisign::PublicKey>::from_base64(s)?;
+        Ok(Self::Minisign(pk))
+    }
+
+    fn from_secret_key(sk_in: AsfaloadSecretKeys) -> Result<Self, KeyError> {
+        match sk_in {
+            AsfaloadSecretKeys::Minisign(sk) => {
+                let pk = AsfaloadPublicKey::<minisign::PublicKey>::from_secret_key(sk)?;
+                Ok(Self::Minisign(pk))
+            }
+        }
+    }
+
+    fn key_format(&self) -> KeyFormat {
+        match self {
+            Self::Minisign(pk) => pk.key_format(),
+        }
+    }
+
+    fn key(&self) -> Self::KeyType {
+        self.to_owned()
+    }
+}
+
+#[derive(Debug)]
+pub enum AsfaloadSecretKeys {
+    Minisign(AsfaloadSecretKey<minisign::SecretKey>),
+}
+
+impl AsfaloadSecretKeyTrait for AsfaloadSecretKeys {
+    type SecretKey = AsfaloadSecretKeys;
+    type Signature = AsfaloadSignatures;
+
+    fn sign(&self, data: &AsfaloadHashes) -> Result<Self::Signature, SignError> {
+        match self {
+            Self::Minisign(sk) => {
+                let sig = sk.sign(data)?;
+                Ok(AsfaloadSignatures::Minisign(sig))
+            }
+        }
+    }
+
+    fn from_bytes(data: &[u8]) -> Result<Self, KeyError> {
+        let sk = AsfaloadSecretKey::<minisign::SecretKey>::from_bytes(data)?;
+        Ok(Self::Minisign(sk))
+    }
+
+    fn from_file<P: AsRef<Path>>(path: P, password: &str) -> Result<Self, KeyError> {
+        let sk = AsfaloadSecretKey::<minisign::SecretKey>::from_file(path, password)?;
+        Ok(Self::Minisign(sk))
+    }
+}
+
+pub enum AsfaloadSignatures {
+    Minisign(AsfaloadSignature<minisign::SignatureBox>),
+}
+
+impl std::fmt::Debug for AsfaloadSignatures {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Minisign(sig) => write!(f, "AsfaloadSignatures::Minisign({})", sig.to_base64()),
+        }
+    }
+}
+
+impl Clone for AsfaloadSignatures {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Minisign(sig) => Self::Minisign(sig.clone()),
+        }
+    }
+}
+
+impl AsfaloadSignatureTrait for AsfaloadSignatures {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Minisign(sig) => sig.to_string(),
+        }
+    }
+
+    fn from_string(data: &str) -> Result<Self, SignatureError> {
+        let sig = AsfaloadSignature::<minisign::SignatureBox>::from_string(data)?;
+        Ok(Self::Minisign(sig))
+    }
+
+    fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<&Self, SignatureError> {
+        match self {
+            Self::Minisign(sig) => {
+                sig.to_file(path)?;
+            }
+        }
+        Ok(self)
+    }
+
+    fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, SignatureError> {
+        let sig = AsfaloadSignature::<minisign::SignatureBox>::from_file(path)?;
+        Ok(Self::Minisign(sig))
+    }
+
+    fn from_base64(s: &str) -> Result<Self, SignatureError> {
+        let sig = AsfaloadSignature::<minisign::SignatureBox>::from_base64(s)?;
+        Ok(Self::Minisign(sig))
+    }
+
+    fn to_base64(&self) -> String {
+        match self {
+            Self::Minisign(sig) => sig.to_base64(),
+        }
+    }
+
+    fn add_to_aggregate_for_file<P: AsRef<Path>, PK: AsfaloadPublicKeyTrait<Signature = Self>>(
+        &self,
+        signed_file: P,
+        pub_key: &PK,
+    ) -> Result<(), SignatureError> {
+        // Check if the path is a directory
+        if signed_file.as_ref().is_dir() {
+            return Err(SignatureError::IoError(std::io::Error::new(
+                std::io::ErrorKind::IsADirectory,
+                "Requires a file, cannot sign a directory",
+            )));
+        }
+
+        let signed_file_path = signed_file.as_ref();
+
+        // Check if aggregate signature is already complete
+        let signatures_path = signatures_path_for(signed_file_path)?;
+        if signatures_path.exists() && signatures_path.is_file() {
+            return Err(SignatureError::IoError(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "Aggregate signature is already complete",
+            )));
+        }
+
+        // Get the pending signatures file path
+        let pending_sig_file_path = pending_signatures_path_for(signed_file_path)?;
+
+        // Read existing signatures, or create a new map if the file doesn't exist
+        let mut signatures_map: std::collections::HashMap<String, String> =
+            match File::open(&pending_sig_file_path) {
+                Ok(file) => serde_json::from_reader(file)?,
+                Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    std::collections::HashMap::new()
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+        // Verify the signature
+        let signed_data = common::sha512_for_file(signed_file_path)?;
+        if pub_key.verify(self, &signed_data).is_ok() {
+            // Add the signature to the map
+            let pubkey_b64 = pub_key.to_base64();
+            signatures_map.insert(pubkey_b64, self.to_base64());
+
+            // Write the updated map back to the file
+            let file = File::create(&pending_sig_file_path)?;
+            serde_json::to_writer_pretty(file, &signatures_map)?;
+
+            Ok(())
+        } else {
+            Err(SignatureError::InvalidSignatureForAggregate(
+                signed_file_path.to_path_buf(),
+            ))
+        }
+    }
+}

--- a/core/signatures/src/types/tests.rs
+++ b/core/signatures/src/types/tests.rs
@@ -1,0 +1,324 @@
+use crate::keys::{
+    AsfaloadKeyPairTrait, AsfaloadPublicKeyTrait, AsfaloadSecretKeyTrait, AsfaloadSignatureTrait,
+};
+use anyhow::{Context, Result};
+use common::errors::keys::{KeyError, SignatureError};
+use common::fs::names::PENDING_SIGNATURES_SUFFIX;
+use std::fs;
+use tempfile::TempDir;
+
+use super::*;
+
+//------------------------------------------------------------
+// Keypairs
+//------------------------------------------------------------
+// Helper to initialise a new key pair and get its keys
+fn get_key_pair() -> Result<(AsfaloadPublicKeys, AsfaloadSecretKeys)> {
+    let kp = AsfaloadKeyPairs::new("mypass")?;
+    Ok((kp.public_key(), kp.secret_key("mypass")?))
+}
+
+// Helper function to create a file to sign
+pub fn create_file_to_sign(dir: std::path::PathBuf) -> Result<std::path::PathBuf, std::io::Error> {
+    let to_signed_file_name = "my_signed_file";
+    let to_signed_file_path = dir.as_path().join(to_signed_file_name);
+    std::fs::write(&to_signed_file_path, "data").map(|_| to_signed_file_path)
+}
+
+#[test]
+fn test_new() -> Result<()> {
+    // Assign keypair then save it on disk, passing a dir
+    let kp = AsfaloadKeyPairs::new("mypass")?;
+    let temp_dir = tempfile::tempdir().context("Unable to create a temporary directory")?;
+    let temp_file_path = temp_dir.path();
+    let _kpr = kp.save(temp_file_path)?;
+    assert!(temp_dir.path().join("key").exists());
+    assert!(temp_dir.path().join("key.pub").exists());
+    // Load keys from just created files
+    let sk = AsfaloadSecretKeys::from_file(temp_dir.path().join("key"), "mypass")?;
+    let pk = AsfaloadPublicKeys::from_file(temp_dir.path().join("key.pub"))?;
+    // We can't access private fields, so we'll just verify that the keys work correctly
+    // by signing and verifying
+    let data = common::sha512_for_content(b"test verification".to_vec())?;
+    let sig = sk.sign(&data)?;
+    pk.verify(&sig, &data)?;
+    // Check we can sign and verify with these keys
+    let data = common::sha512_for_content(b"lorem ipsum".to_vec())?;
+    let sig = sk.sign(&data)?;
+    pk.verify(&sig, &data)?;
+
+    // Assign keypair then save it on disk, passing a file name
+    let kp = AsfaloadKeyPairs::new("mypass")?;
+    let temp_dir = tempfile::tempdir().context("Unable to create a temporary directory")?;
+    let temp_file_path = temp_dir.path().join("mykey");
+    let _kpr = kp.save(&temp_file_path)?;
+    assert!(temp_dir.path().join("mykey").exists());
+    assert!(temp_dir.path().join("mykey.pub").exists());
+
+    // Saving keys does not overwrite existing files
+    // ---------------------------------------------
+    fn panic_if_writing_file(save_result: Result<&AsfaloadKeyPairs, KeyError>) {
+        match save_result {
+            Ok(_) => panic!("should not overwrite existing file!"),
+            Err(e) => match e {
+                KeyError::NotOverwriting(_) => (),
+                _ => panic!("should not overwrite files!"),
+            },
+        }
+    }
+    let temp_dir = tempfile::tempdir().unwrap();
+    // Default name "key"
+    let existing_default_path = temp_dir.path().join("key");
+    File::create(&existing_default_path)?;
+    let kp = AsfaloadKeyPairs::new("mypass")?;
+    let save_result = kp.save(&temp_dir);
+    panic_if_writing_file(save_result);
+    fs::remove_file(existing_default_path)?;
+
+    // Default name "key.pub"
+    let existing_default_path = temp_dir.path().join("key.pub");
+    File::create(&existing_default_path)?;
+    let kp = AsfaloadKeyPairs::new("mypass")?;
+    let save_result = kp.save(&temp_dir);
+    panic_if_writing_file(save_result);
+    fs::remove_file(existing_default_path)?;
+
+    // Custom file name, priv exists
+    let temp_file_path = temp_dir.path().join("mykey");
+    File::create(&temp_file_path)?;
+    let kp = AsfaloadKeyPairs::new("mypass")?;
+    let save_result = kp.save(&temp_file_path);
+    panic_if_writing_file(save_result);
+    fs::remove_file(&temp_file_path)?;
+
+    // Custom file name, pub exists
+    let pub_temp_file_path = temp_dir.path().join("mykey.pub");
+    File::create(&pub_temp_file_path)?;
+    let kp = AsfaloadKeyPairs::new("mypass")?;
+    let save_result = kp.save(&temp_file_path);
+    panic_if_writing_file(save_result);
+    fs::remove_file(pub_temp_file_path)?;
+
+    // Call new and save on the same line
+    let temp_dir = tempfile::tempdir().context("Unable to create a temporary directory")?;
+    let temp_file_path = temp_dir.path().join("key");
+    let _kp = AsfaloadKeyPairs::new("mypass")?.save(temp_file_path)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_keys_methods() -> Result<()> {
+    // Save keypair in temp dir
+    let temp_dir = tempfile::tempdir().unwrap();
+    let kp = AsfaloadKeyPairs::new("mypass")?;
+    kp.save(&temp_dir)?;
+
+    // Load secret key from disk
+    let secret_key_path = temp_dir.as_ref().to_path_buf().join("key");
+    let secret_key = AsfaloadSecretKeys::from_file(secret_key_path, "mypass")?;
+
+    // Generate signature
+    let bytes_to_sign = common::sha512_for_content(b"My string to sign".to_vec())?;
+    let signature = secret_key.sign(&bytes_to_sign)?;
+
+    // Load public key from disk
+    let public_key_path = temp_dir.as_ref().to_path_buf().join("key.pub");
+    let public_key = AsfaloadPublicKeys::from_file(&public_key_path)?;
+
+    // Verify signature
+    public_key.verify(&signature, &bytes_to_sign)?;
+
+    // Load key from base64 and validate
+    let value_read = fs::read_to_string(&public_key_path)?;
+    // When we saved the key to disk using the minisign Box, it wrote a comment
+    // followed by the base64 encoded key. Thus here we only need the second line.
+    let public_key_string = value_read.lines().nth(1).ok_or_else(|| {
+        KeyError::IOError(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Public key file does not contain a second line",
+        ))
+    })?;
+    let public_key_from_string = AsfaloadPublicKeys::from_base64(public_key_string.to_string())?;
+    public_key_from_string.verify(&signature, &bytes_to_sign)?;
+
+    // Test AsfaloadPublicKey::from_base64
+    let b64 = public_key_from_string.to_base64();
+    assert_eq!(b64, public_key_string);
+
+    Ok(())
+}
+
+#[test]
+fn test_signature_from_string_formats() -> Result<()> {
+    let (pk, sk) = get_key_pair()?;
+    let data = common::sha512_for_content(b"lorem ipsum".to_vec())?;
+    let sig = sk.sign(&data)?;
+
+    // String serialisation
+    let sig_str = sig.to_string();
+    let sig_from_str = AsfaloadSignatures::from_string(sig_str.as_str())?;
+    pk.verify(&sig_from_str, &data)?;
+
+    // Base64 serialisation
+    let sig_b64 = sig.to_base64();
+    let sig_from_b64 = AsfaloadSignatures::from_base64(&sig_b64)?;
+    pk.verify(&sig_from_b64, &data)?;
+
+    // Saving signature to file
+    let temp_dir = TempDir::new()?;
+    let root_dir = temp_dir.as_ref();
+    let sig_path = root_dir.join("signature");
+    sig.to_file(&sig_path)?;
+
+    // Reading signature from file
+    let sig_from_file = AsfaloadSignatures::from_file(sig_path)?;
+    pk.verify(&sig_from_file, &data)?;
+
+    Ok(())
+}
+
+#[test]
+fn test_add_to_aggregate() -> Result<()> {
+    // Create a temporary directory
+    let temp_dir = tempfile::tempdir()?;
+    let dir_path = temp_dir.path();
+    let signed_file_path = create_file_to_sign(dir_path.to_path_buf())?;
+    std::fs::write(&signed_file_path, "test data")?;
+
+    // Generate a keypair and create a signature
+    let keypair = AsfaloadKeyPairs::new("password")?;
+    let pubkey = keypair.public_key();
+    let seckey = keypair.secret_key("password")?;
+
+    let keypair2 = AsfaloadKeyPairs::new("password")?;
+    let pubkey2 = keypair2.public_key();
+    let seckey2 = keypair2.secret_key("password")?;
+
+    let data = common::sha512_for_content(b"test data".to_vec())?;
+    let wrong_data = common::sha512_for_content(b"wrong data".to_vec())?;
+    let signature = seckey.sign(&data)?;
+    let signature2 = seckey2.sign(&data)?;
+    let wrong_signature = seckey.sign(&wrong_data)?;
+
+    // Signing a directory causes an error
+    let result = signature.add_to_aggregate_for_file(dir_path, &pubkey);
+    assert!(result.is_err());
+    match result.as_ref().unwrap_err() {
+        SignatureError::IoError(io_err) => {
+            let err: &std::io::Error = io_err; // Explicit type annotation
+            if err.kind() != std::io::ErrorKind::IsADirectory {
+                panic!(
+                    "Expected IoError with IsADirectory kind, got something else: {:?}",
+                    err
+                )
+            }
+        }
+        _ => panic!(
+            "Expected SignatureError, got something else: {:?}",
+            result.unwrap_err()
+        ),
+    }
+
+    // Attempting to add the signature of another data than the signed file's hash to the aggregate should fail.
+    let result = wrong_signature.add_to_aggregate_for_file(&signed_file_path, &pubkey);
+    match result {
+        Err(SignatureError::InvalidSignatureForAggregate(_)) => {
+            // Expected
+        }
+        Ok(_) => panic!("Expected an error, but got Ok"),
+        _ => panic!(
+            "Expected InvalidsignatureForAggregate, got something else: {:?}",
+            result.unwrap_err()
+        ),
+    }
+
+    // Add the signature to the aggregate
+    signature.add_to_aggregate_for_file(&signed_file_path, &pubkey)?;
+
+    // Verify that the signature file was created
+    let sig_file_path = signed_file_path.with_file_name(format!(
+        "{}.{}",
+        signed_file_path.to_string_lossy(),
+        PENDING_SIGNATURES_SUFFIX
+    ));
+    assert!(
+        sig_file_path.exists(),
+        "Pending signature file should exist"
+    );
+
+    // Verify the content of the signatures file
+    let sig_file_content = std::fs::read_to_string(&sig_file_path)?;
+    let sig_file: std::collections::HashMap<String, String> =
+        serde_json::from_str(&sig_file_content)?;
+    let pubkey_b64 = pubkey.to_base64();
+    let pubkey2_b64 = pubkey2.to_base64();
+    assert!(
+        sig_file.contains_key(&pubkey_b64),
+        "Signatures file should contain an entry for the public key"
+    );
+    assert!(
+        !sig_file.contains_key(&pubkey2_b64),
+        "Signatures file should NOT contain an entry for the second public key"
+    );
+    assert_eq!(
+        sig_file.get(&pubkey_b64).unwrap(),
+        &signature.to_base64(),
+        "Signatures file should contain the correct signature"
+    );
+
+    // Add second signature to aggregate
+    signature2.add_to_aggregate_for_file(signed_file_path, &pubkey2)?;
+
+    // Re-read the signatures file as it should have been modified
+    let sig_file_content = std::fs::read_to_string(&sig_file_path)?;
+    let sig_file: std::collections::HashMap<String, String> =
+        serde_json::from_str(&sig_file_content)?;
+    // First signature is still there
+    assert!(
+        sig_file.contains_key(&pubkey_b64),
+        "Signatures file should contain an entry for the public key"
+    );
+    assert_eq!(
+        sig_file.get(&pubkey_b64).unwrap(),
+        &signature.to_base64(),
+        "Signatures file should contain the correct signature"
+    );
+    // Second signature is added
+    assert!(
+        sig_file.contains_key(&pubkey2_b64),
+        "Signatures file should contain an entry for the second public key"
+    );
+    assert_eq!(
+        sig_file.get(&pubkey2_b64).unwrap(),
+        &signature2.to_base64(),
+        "Signatures file should contain the correct second signature"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_signature_trait_error_mapping() -> Result<()> {
+    // Check underlying IO errors are mapped correctly to our IO error.
+    let r = AsfaloadSignatures::from_file("/tmp/inexisting_path");
+    assert!(matches!(r, Err(SignatureError::IoError(_))));
+
+    let r = AsfaloadSignatures::from_base64("invalid");
+    assert!(matches!(r, Err(SignatureError::Base64DecodeFailed(_))));
+
+    // This seems to be reported as IO error by minisign
+    let r = AsfaloadSignatures::from_string("invalid");
+    assert!(matches!(r, Err(SignatureError::IoError(_))));
+    Ok(())
+}
+
+#[test]
+fn test_public_key_from_secret_key() -> Result<()> {
+    let kp = AsfaloadKeyPairs::new("mypass")?;
+    let pubkey = kp.public_key();
+    let seckey = kp.secret_key("mypass")?;
+
+    let derived_pubkey = AsfaloadPublicKeys::from_secret_key(seckey)?;
+    assert_eq!(derived_pubkey.to_base64(), pubkey.to_base64());
+    Ok(())
+}

--- a/core/signers_file/src/lib.rs
+++ b/core/signers_file/src/lib.rs
@@ -9,7 +9,7 @@ use common::{
     },
 };
 use signatures::{
-    keys::AsfaloadPublicKeyTrait,
+    keys::{AsfaloadPublicKeyTrait, AsfaloadSignatureTrait},
     types::{AsfaloadPublicKeys, AsfaloadSignatures},
 };
 use signers_file_types::{
@@ -71,15 +71,13 @@ fn is_valid_signer_for_update_of(
     }
 }
 
-pub fn sign_signers_file<P, S, K>(
+pub fn sign_signers_file<P>(
     signers_file_path: P,
-    signature: &S,
-    pubkey: &K,
+    signature: &AsfaloadSignatures,
+    pubkey: &AsfaloadPublicKeys,
 ) -> Result<SignatureWithState, SignersFileError>
 where
     P: AsRef<Path>,
-    K: AsfaloadPublicKeyTrait<Signature = S> + std::cmp::Eq + std::clone::Clone + std::hash::Hash,
-    S: signatures::keys::AsfaloadSignatureTrait + std::clone::Clone,
 {
     let signed_file = SignedFileLoader::load(&signers_file_path);
     if !(signed_file.is_initial_signers() || signed_file.is_signers()) {
@@ -137,17 +135,13 @@ where
 /// # Returns
 /// * `Ok(())` if the pending file was successfully created
 /// * `Err(SignersFileError)` if there was an error validating the JSON, signature, or writing the file
-pub fn write_valid_signers_file<P: AsRef<Path>, S, K>(
+pub fn write_valid_signers_file<P: AsRef<Path>>(
     dir_path_in: P,
     json_content: &str,
-    signature: &S,
-    pubkey: &K,
+    signature: &AsfaloadSignatures,
+    pubkey: &AsfaloadPublicKeys,
     validator: impl FnOnce() -> Result<(), SignersFileError>,
-) -> Result<(), SignersFileError>
-where
-    K: AsfaloadPublicKeyTrait<Signature = S> + std::cmp::Eq + std::clone::Clone + std::hash::Hash,
-    S: signatures::keys::AsfaloadSignatureTrait + std::clone::Clone,
-{
+) -> Result<(), SignersFileError> {
     // Ensure we work in the right directory
 
     let dir_path = {

--- a/core/test_helpers/src/lib.rs
+++ b/core/test_helpers/src/lib.rs
@@ -1,12 +1,12 @@
-use signatures::keys::AsfaloadKeyPair;
 use signatures::keys::AsfaloadKeyPairTrait;
-use signatures::keys::AsfaloadPublicKey;
 use signatures::keys::AsfaloadPublicKeyTrait;
-use signatures::keys::AsfaloadSecretKey;
+use signatures::types::AsfaloadKeyPairs;
+use signatures::types::AsfaloadPublicKeys;
+use signatures::types::AsfaloadSecretKeys;
 pub struct TestKeys {
-    key_pairs: Vec<AsfaloadKeyPair<minisign::KeyPair>>,
-    pub_keys: Vec<AsfaloadPublicKey<minisign::PublicKey>>,
-    sec_keys: Vec<AsfaloadSecretKey<minisign::SecretKey>>,
+    key_pairs: Vec<AsfaloadKeyPairs>,
+    pub_keys: Vec<AsfaloadPublicKeys>,
+    sec_keys: Vec<AsfaloadSecretKeys>,
 }
 
 impl TestKeys {
@@ -17,7 +17,7 @@ impl TestKeys {
             sec_keys: Vec::with_capacity(n),
         };
         for _ in 0..n {
-            let key_pair = AsfaloadKeyPair::new("password").unwrap();
+            let key_pair = AsfaloadKeyPairs::new("password").unwrap();
             let pub_key = key_pair.public_key();
             let sec_key = key_pair.secret_key("password").unwrap();
             r.key_pairs.push(key_pair);
@@ -28,13 +28,13 @@ impl TestKeys {
         r
     }
 
-    pub fn pub_key(&self, n: usize) -> Option<&AsfaloadPublicKey<minisign::PublicKey>> {
+    pub fn pub_key(&self, n: usize) -> Option<&AsfaloadPublicKeys> {
         self.pub_keys.get(n)
     }
-    pub fn sec_key(&self, n: usize) -> Option<&AsfaloadSecretKey<minisign::SecretKey>> {
+    pub fn sec_key(&self, n: usize) -> Option<&AsfaloadSecretKeys> {
         self.sec_keys.get(n)
     }
-    pub fn key_pair(&self, n: usize) -> Option<&AsfaloadKeyPair<minisign::KeyPair>> {
+    pub fn key_pair(&self, n: usize) -> Option<&AsfaloadKeyPairs> {
         self.key_pairs.get(n)
     }
 

--- a/rest-api/run.sh
+++ b/rest-api/run.sh
@@ -2,6 +2,8 @@
 
 set -euxo pipefail
 
+echo "using git repo path: ${1?provide path to git repo}"
+
 # Check if a git directory path was provided
 if [ -z "$1" ]; then
   echo "Error: No git directory path provided a first argument."

--- a/rest_api_auth/Cargo.toml
+++ b/rest_api_auth/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rest_api_auth"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+chrono = "0.4.42"
+uuid = { version = "1.19.0", features = ["v4"] }
+features_lib = { path = "../core/features_lib/" }
+thiserror = "2.0.17"
+
+[lints]
+workspace = true

--- a/rest_api_auth/Cargo.toml
+++ b/rest_api_auth/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 chrono = "0.4.42"
 uuid = { version = "1.19.0", features = ["v4"] }
 features_lib = { path = "../core/features_lib/" }
+signatures = { path = "../core/signatures/" }
 thiserror = "2.0.17"
 
 [lints]

--- a/rest_api_auth/Cargo.toml
+++ b/rest_api_auth/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 chrono = "0.4.42"
 uuid = { version = "1.19.0", features = ["v4"] }
 features_lib = { path = "../core/features_lib/" }
-signatures = { path = "../core/signatures/" }
 thiserror = "2.0.17"
 
 [lints]

--- a/rest_api_auth/src/lib.rs
+++ b/rest_api_auth/src/lib.rs
@@ -34,9 +34,9 @@ pub struct AuthInfo {
     payload: String,
 }
 
-pub struct AuthSignature<MP, MS>
+pub struct AuthSignature<MP, MS, MSK>
 where
-    PublicKey<MP>: PublicKeyTrait,
+    PublicKey<MP>: PublicKeyTrait<SecretKeyType = MSK>,
     Signature<MS>: SignatureTrait,
     MP: Clone,
     MS: Clone,
@@ -68,16 +68,15 @@ impl AuthInfo {
     }
 }
 
-impl<MP, MS> AuthSignature<MP, MS>
+impl<MP, MS, MSK> AuthSignature<MP, MS, MSK>
 where
-    PublicKey<MP>: PublicKeyTrait,
+    PublicKey<MP>: PublicKeyTrait<SecretKeyType = MSK>,
     Signature<MS>: SignatureTrait,
     MP: Clone,
     MS: Clone,
 {
-    pub fn new<MSK>(auth_info: AuthInfo, secret_key: SecretKey<MSK>) -> Result<Self, AuthError>
+    pub fn new(auth_info: AuthInfo, secret_key: SecretKey<MSK>) -> Result<Self, AuthError>
     where
-        PublicKey<MP>: PublicKeyTrait<SecretKeyType = MSK>,
         SecretKey<MSK>: SecretKeyTrait<Signature = Signature<MS>, SecretKey = MSK>,
     {
         let hash = sha512_for_content(auth_info.to_string().as_bytes().to_vec())?;

--- a/rest_api_auth/src/lib.rs
+++ b/rest_api_auth/src/lib.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Utc};
 use features_lib::{
-    PublicKey, PublicKeyTrait, SecretKey, SecretKeyTrait, Signature,
+    AsfaloadPublicKeys, AsfaloadSecretKeys, AsfaloadSignatures,
     errors::keys::{KeyError, SignError},
     sha512_for_content,
 };
+use signatures::keys::{AsfaloadPublicKeyTrait, AsfaloadSecretKeyTrait};
 use thiserror::Error;
 use uuid::Uuid;
 
@@ -37,9 +38,9 @@ pub struct AuthInfo {
 pub struct AuthSignature {
     auth_info: AuthInfo,
     // Will be set by client as X-asfld-sig
-    signature: Signature,
+    signature: AsfaloadSignatures,
     // Will be set by client as X-asfld-pk
-    public_key: PublicKey,
+    public_key: AsfaloadPublicKeys,
 }
 
 impl AuthInfo {
@@ -63,10 +64,10 @@ impl AuthInfo {
 }
 
 impl AuthSignature {
-    pub fn new(auth_info: AuthInfo, secret_key: SecretKey) -> Result<Self, AuthError> {
+    pub fn new(auth_info: AuthInfo, secret_key: AsfaloadSecretKeys) -> Result<Self, AuthError> {
         let hash = sha512_for_content(auth_info.to_string().as_bytes().to_vec())?;
         let signature = secret_key.sign(&hash)?;
-        let public_key = PublicKey::from_secret_key(secret_key.key)?;
+        let public_key = AsfaloadPublicKeys::from_secret_key(secret_key)?;
         Ok(AuthSignature {
             auth_info,
             signature,
@@ -77,7 +78,7 @@ impl AuthSignature {
     pub fn auth_info(&self) -> AuthInfo {
         self.auth_info.clone()
     }
-    pub fn signature(&self) -> Signature {
+    pub fn signature(&self) -> AsfaloadSignatures {
         self.signature.clone()
     }
     pub fn public_key(&self) -> String {

--- a/rest_api_auth/src/lib.rs
+++ b/rest_api_auth/src/lib.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use features_lib::{
-    PublicKey, PublicKeyTrait, SecretKey, SecretKeyTrait, Signature, SignatureTrait,
+    PublicKey, PublicKeyTrait, SecretKey, SecretKeyTrait, Signature,
     errors::keys::{KeyError, SignError},
     sha512_for_content,
 };
@@ -34,18 +34,12 @@ pub struct AuthInfo {
     payload: String,
 }
 
-pub struct AuthSignature<MP, MS, MSK>
-where
-    PublicKey<MP>: PublicKeyTrait<SecretKeyType = MSK>,
-    Signature<MS>: SignatureTrait,
-    MP: Clone,
-    MS: Clone,
-{
+pub struct AuthSignature {
     auth_info: AuthInfo,
     // Will be set by client as X-asfld-sig
-    signature: Signature<MS>,
+    signature: Signature,
     // Will be set by client as X-asfld-pk
-    public_key: PublicKey<MP>,
+    public_key: PublicKey,
 }
 
 impl AuthInfo {
@@ -68,17 +62,8 @@ impl AuthInfo {
     }
 }
 
-impl<MP, MS, MSK> AuthSignature<MP, MS, MSK>
-where
-    PublicKey<MP>: PublicKeyTrait<SecretKeyType = MSK>,
-    Signature<MS>: SignatureTrait,
-    MP: Clone,
-    MS: Clone,
-{
-    pub fn new(auth_info: AuthInfo, secret_key: SecretKey<MSK>) -> Result<Self, AuthError>
-    where
-        SecretKey<MSK>: SecretKeyTrait<Signature = Signature<MS>, SecretKey = MSK>,
-    {
+impl AuthSignature {
+    pub fn new(auth_info: AuthInfo, secret_key: SecretKey) -> Result<Self, AuthError> {
         let hash = sha512_for_content(auth_info.to_string().as_bytes().to_vec())?;
         let signature = secret_key.sign(&hash)?;
         let public_key = PublicKey::from_secret_key(secret_key.key)?;
@@ -92,7 +77,7 @@ where
     pub fn auth_info(&self) -> AuthInfo {
         self.auth_info.clone()
     }
-    pub fn signature(&self) -> Signature<MS> {
+    pub fn signature(&self) -> Signature {
         self.signature.clone()
     }
     pub fn public_key(&self) -> String {

--- a/rest_api_auth/src/lib.rs
+++ b/rest_api_auth/src/lib.rs
@@ -1,0 +1,114 @@
+use chrono::{DateTime, Utc};
+use features_lib::{
+    PublicKey, PublicKeyTrait, SecretKey, SecretKeyTrait, Signature, SignatureTrait,
+    errors::keys::{KeyError, SignError},
+    sha512_for_content,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+#[derive(Error, Debug)]
+pub enum AuthError {
+    #[error("Auth data preparation error: {0}")]
+    AuthDataPreparationError(String),
+
+    #[error("Auth io error: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Auth signing error: {0}")]
+    SigningError(#[from] SignError),
+
+    #[error("Auth key error: {0}")]
+    KeyError(#[from] KeyError),
+}
+
+// Struct holding information that will be used in authentication
+// by rest clients and servers
+#[derive(Clone)]
+pub struct AuthInfo {
+    // Will be set by client as X-asfld-timestamp
+    timestamp: DateTime<Utc>,
+    // Will be set by client as X-asfld-nonce
+    nonce: Uuid,
+    // Is the payload sent by the client to the server
+    payload: String,
+}
+
+pub struct AuthSignature<MP, MS>
+where
+    PublicKey<MP>: PublicKeyTrait,
+    Signature<MS>: SignatureTrait,
+    MP: Clone,
+    MS: Clone,
+{
+    auth_info: AuthInfo,
+    // Will be set by client as X-asfld-sig
+    signature: Signature<MS>,
+    // Will be set by client as X-asfld-pk
+    public_key: PublicKey<MP>,
+}
+
+impl AuthInfo {
+    pub fn new(payload: String) -> Self {
+        let nonce = Uuid::new_v4();
+        let timestamp = chrono::Utc::now();
+        AuthInfo {
+            timestamp,
+            nonce,
+            payload,
+        }
+    }
+
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+
+    pub fn nonce(&self) -> String {
+        self.nonce.to_string()
+    }
+}
+
+impl<MP, MS> AuthSignature<MP, MS>
+where
+    PublicKey<MP>: PublicKeyTrait,
+    Signature<MS>: SignatureTrait,
+    MP: Clone,
+    MS: Clone,
+{
+    pub fn new<MSK>(auth_info: AuthInfo, secret_key: SecretKey<MSK>) -> Result<Self, AuthError>
+    where
+        PublicKey<MP>: PublicKeyTrait<SecretKeyType = MSK>,
+        SecretKey<MSK>: SecretKeyTrait<Signature = Signature<MS>, SecretKey = MSK>,
+    {
+        let hash = sha512_for_content(auth_info.to_string().as_bytes().to_vec())?;
+        let signature = secret_key.sign(&hash)?;
+        let public_key = PublicKey::from_secret_key(secret_key.key)?;
+        Ok(AuthSignature {
+            auth_info,
+            signature,
+            public_key,
+        })
+    }
+
+    pub fn auth_info(&self) -> AuthInfo {
+        self.auth_info.clone()
+    }
+    pub fn signature(&self) -> Signature<MS> {
+        self.signature.clone()
+    }
+    pub fn public_key(&self) -> String {
+        self.public_key.to_base64()
+    }
+}
+
+impl std::fmt::Display for AuthInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}##{}##{}",
+            self.timestamp.to_rfc3339(),
+            self.nonce,
+            self.payload
+        )
+    }
+}

--- a/rest_api_auth/src/lib.rs
+++ b/rest_api_auth/src/lib.rs
@@ -1,10 +1,10 @@
 use chrono::{DateTime, Utc};
 use features_lib::{
     AsfaloadPublicKeys, AsfaloadSecretKeys, AsfaloadSignatures,
+    AsfaloadPublicKeyTrait, AsfaloadSecretKeyTrait,
     errors::keys::{KeyError, SignError},
     sha512_for_content,
 };
-use signatures::keys::{AsfaloadPublicKeyTrait, AsfaloadSecretKeyTrait};
 use thiserror::Error;
 use uuid::Uuid;
 


### PR DESCRIPTION
This started as work on authentication for the rest-api server. However, in the course of that development, it appeared the genericity of the code transpired to the code of the end user: when I defined a dummy signing scheme in addition to minisign, lots of code required adaptation: it only worked until now because there was only one signing scheme defined. So the work switched to improve the genericity and isolate the end coder of it.  The approach taken is to define enums with one case for each signing scheme defined. The work on the rest authentication included in this PR is not working, but extracting it is too much work, so a future PR will fix it.