### PR TITLE
feat: rest api versioning

### DIFF
--- a/client-cli/src/rest_client.rs
+++ b/client-cli/src/rest_client.rs
@@ -1,13 +1,13 @@
+mod v1;
+
 use crate::error::{ClientCliError, Result};
 use crate::utils::create_auth_headers;
-use features_lib::{
-    AsfaloadPublicKeyTrait, AsfaloadPublicKeys, AsfaloadSecretKeys, AsfaloadSignatureTrait,
-};
+use features_lib::AsfaloadSecretKeys;
 use reqwest::Client;
-use rest_api_types::{
-    ListPendingResponse, RegisterReleaseResponse, SubmitSignatureRequest, SubmitSignatureResponse,
-};
 use serde_json::Value;
+
+// Re-export v1 endpoint functions as the current API surface
+pub use v1::{fetch_file, get_pending_signatures, register_release, submit_signature};
 
 /// A client for interacting with the REST API with authentication
 pub struct RestClient {
@@ -33,7 +33,7 @@ impl RestClient {
     ///
     /// # Arguments
     ///
-    /// * `endpoint` - The API endpoint (e.g., "add-file")
+    /// * `endpoint` - The API endpoint (e.g., "v1/add-file")
     /// * `payload` - The JSON payload to send
     /// * `secret_key` - The secret key for authentication
     ///
@@ -83,236 +83,4 @@ impl RestClient {
 
         Ok(response_json)
     }
-}
-
-/// List pending signature files from the backend.
-///
-/// Makes an authenticated GET request to /pending_signatures endpoint.
-///
-/// # Arguments
-///
-/// * `backend_url` - Base URL of the backend API
-/// * `secret_key` - Your secret key for signing the request
-///
-/// # Returns
-///
-/// List of file paths that need your signature
-///
-/// # Errors
-///
-/// Returns error if:
-/// - Authentication fails
-/// - Backend returns non-200 status
-/// - Response is malformed
-pub async fn get_pending_signatures(
-    backend_url: &str,
-    secret_key: AsfaloadSecretKeys,
-) -> Result<ListPendingResponse> {
-    let url = format!("{}/pending_signatures", backend_url);
-
-    // Create auth headers (using empty payload for GET request)
-    let headers = create_auth_headers("", secret_key)?;
-
-    let client = Client::new();
-    let response = client
-        .get(&url)
-        .headers(headers)
-        .send()
-        .await
-        .map_err(|e| ClientCliError::NetworkError(e.to_string()))?;
-
-    if !response.status().is_success() {
-        return Err(ClientCliError::RequestFailed(format!(
-            "{}: {}",
-            response.status(),
-            response.text().await.unwrap_or("".to_string())
-        )));
-    }
-
-    let response_body: ListPendingResponse = response.json().await.map_err(|e| {
-        ClientCliError::ResponseParseError(format!("Failed to parse response: {}", e))
-    })?;
-
-    Ok(response_body)
-}
-
-/// Fetch file content from the backend.
-///
-/// This is a helper for the sign-pending workflow. The client needs to
-/// fetch the actual file content to compute its hash and sign it.
-///
-/// # Arguments
-///
-/// * `backend_url` - Base URL of the backend API
-/// * `file_path` - Relative path to the file (as returned by list-pending)
-///
-/// # Returns
-///
-/// The file content as bytes
-///
-/// # Errors
-///
-/// Returns error if:
-/// - Backend returns non-200 status
-/// - Network error occurs
-pub async fn fetch_file(backend_url: &str, file_path: &str) -> Result<Vec<u8>> {
-    let url = format!("{}/files/{}", backend_url, file_path);
-
-    let client = Client::new();
-    let response = client
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| ClientCliError::NetworkError(e.to_string()))?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let error_text = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "Unknown error".to_string());
-        return Err(ClientCliError::RequestFailed(format!(
-            "GET {}: {} - {}",
-            url, status, error_text
-        )));
-    }
-
-    let content = response.bytes().await.map_err(|e| {
-        ClientCliError::ResponseParseError(format!("Failed to read response: {}", e))
-    })?;
-
-    Ok(content.to_vec())
-}
-
-/// Submit a signature for a file to the backend.
-///
-/// Makes an authenticated POST request to /signatures endpoint with the signature data.
-///
-/// # Arguments
-///
-/// * `backend_url` - Base URL of the backend API
-/// * `file_path` - Relative path to the file being signed
-/// * `public_key` - The signer's public key
-/// * `signature` - The signature data
-/// * `secret_key` - The secret key for authentication
-///
-/// # Returns
-///
-/// Submission response indicating whether the aggregate signature is now complete
-///
-/// # Errors
-///
-/// Returns error if:
-/// - Authentication fails
-/// - Backend returns non-200 status
-/// - Response is malformed
-pub async fn submit_signature(
-    backend_url: &str,
-    file_path: &str,
-    public_key: &AsfaloadPublicKeys,
-    signature: &features_lib::AsfaloadSignatures,
-    secret_key: &AsfaloadSecretKeys,
-) -> Result<SubmitSignatureResponse> {
-    let url = format!("{}/signatures", backend_url);
-
-    // Build the request
-    let request = SubmitSignatureRequest {
-        file_path: file_path.to_string(),
-        public_key: public_key.to_base64(),
-        signature: signature.to_base64(),
-    };
-
-    // Create auth headers
-    let request_json = serde_json::to_string(&request)
-        .map_err(|e| ClientCliError::InvalidInput(format!("Failed to serialize request: {}", e)))?;
-    let headers = create_auth_headers(&request_json, secret_key.clone())?;
-
-    let client = Client::new();
-    let response = client
-        .post(&url)
-        .headers(headers)
-        .json(&request)
-        .send()
-        .await
-        .map_err(|e| ClientCliError::NetworkError(e.to_string()))?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let error_text = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "Unknown error".to_string());
-        return Err(ClientCliError::RequestFailed(format!(
-            "{}: {}",
-            status, error_text
-        )));
-    }
-
-    let response_body: SubmitSignatureResponse = response.json().await.map_err(|e| {
-        ClientCliError::ResponseParseError(format!("Failed to parse response: {}", e))
-    })?;
-
-    Ok(response_body)
-}
-
-/// Register a GitHub release with the backend.
-///
-/// Makes an authenticated POST request to /release endpoint.
-///
-/// # Arguments
-///
-/// * `backend_url` - Base URL of the backend API
-/// * `release_url` - URL of the GitHub release to register
-/// * `secret_key` - The secret key for signing the request
-///
-/// # Returns
-///
-/// Registration response with success status and index file path
-///
-/// # Errors
-///
-/// Returns error if:
-/// - Authentication fails
-/// - Backend returns non-200 status
-/// - Response is malformed
-pub async fn register_release(
-    backend_url: &str,
-    release_url: &str,
-    secret_key: AsfaloadSecretKeys,
-) -> Result<RegisterReleaseResponse> {
-    let url = format!("{}/release", backend_url);
-
-    let payload = serde_json::json!({
-        "release_url": release_url
-    });
-
-    let payload_string = payload.to_string();
-    let headers = create_auth_headers(&payload_string, secret_key)?;
-
-    let client = Client::new();
-    let response = client
-        .post(&url)
-        .headers(headers)
-        .json(&payload)
-        .send()
-        .await
-        .map_err(|e| ClientCliError::NetworkError(e.to_string()))?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let error_text = match response.text().await {
-            Ok(text) => text,
-            Err(e) => format!("(could not read response body: {})", e),
-        };
-        return Err(ClientCliError::RequestFailed(format!(
-            "{}: {}",
-            status, error_text
-        )));
-    }
-
-    let response_body: RegisterReleaseResponse = response.json().await.map_err(|e| {
-        ClientCliError::ResponseParseError(format!("Failed to parse response: {}", e))
-    })?;
-
-    Ok(response_body)
 }

--- a/client-cli/src/rest_client/v1.rs
+++ b/client-cli/src/rest_client/v1.rs
@@ -1,0 +1,241 @@
+use crate::error::{ClientCliError, Result};
+use crate::utils::create_auth_headers;
+use features_lib::{
+    AsfaloadPublicKeyTrait, AsfaloadPublicKeys, AsfaloadSecretKeys, AsfaloadSignatureTrait,
+};
+use reqwest::Client;
+use rest_api_types::{
+    ListPendingResponse, RegisterReleaseResponse, SubmitSignatureRequest, SubmitSignatureResponse,
+};
+
+/// List pending signature files from the backend.
+///
+/// Makes an authenticated GET request to /v1/pending_signatures endpoint.
+///
+/// # Arguments
+///
+/// * `backend_url` - Base URL of the backend API
+/// * `secret_key` - Your secret key for signing the request
+///
+/// # Returns
+///
+/// List of file paths that need your signature
+///
+/// # Errors
+///
+/// Returns error if:
+/// - Authentication fails
+/// - Backend returns non-200 status
+/// - Response is malformed
+pub async fn get_pending_signatures(
+    backend_url: &str,
+    secret_key: AsfaloadSecretKeys,
+) -> Result<ListPendingResponse> {
+    let url = format!("{}/v1/pending_signatures", backend_url);
+
+    // Create auth headers (using empty payload for GET request)
+    let headers = create_auth_headers("", secret_key)?;
+
+    let client = Client::new();
+    let response = client
+        .get(&url)
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|e| ClientCliError::NetworkError(e.to_string()))?;
+
+    if !response.status().is_success() {
+        return Err(ClientCliError::RequestFailed(format!(
+            "{}: {}",
+            response.status(),
+            response.text().await.unwrap_or("".to_string())
+        )));
+    }
+
+    let response_body: ListPendingResponse = response.json().await.map_err(|e| {
+        ClientCliError::ResponseParseError(format!("Failed to parse response: {}", e))
+    })?;
+
+    Ok(response_body)
+}
+
+/// Fetch file content from the backend.
+///
+/// This is a helper for the sign-pending workflow. The client needs to
+/// fetch the actual file content to compute its hash and sign it.
+///
+/// # Arguments
+///
+/// * `backend_url` - Base URL of the backend API
+/// * `file_path` - Relative path to the file (as returned by list-pending)
+///
+/// # Returns
+///
+/// The file content as bytes
+///
+/// # Errors
+///
+/// Returns error if:
+/// - Backend returns non-200 status
+/// - Network error occurs
+pub async fn fetch_file(backend_url: &str, file_path: &str) -> Result<Vec<u8>> {
+    let url = format!("{}/v1/files/{}", backend_url, file_path);
+
+    let client = Client::new();
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| ClientCliError::NetworkError(e.to_string()))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(ClientCliError::RequestFailed(format!(
+            "GET {}: {} - {}",
+            url, status, error_text
+        )));
+    }
+
+    let content = response.bytes().await.map_err(|e| {
+        ClientCliError::ResponseParseError(format!("Failed to read response: {}", e))
+    })?;
+
+    Ok(content.to_vec())
+}
+
+/// Submit a signature for a file to the backend.
+///
+/// Makes an authenticated POST request to /v1/signatures endpoint with the signature data.
+///
+/// # Arguments
+///
+/// * `backend_url` - Base URL of the backend API
+/// * `file_path` - Relative path to the file being signed
+/// * `public_key` - The signer's public key
+/// * `signature` - The signature data
+/// * `secret_key` - The secret key for authentication
+///
+/// # Returns
+///
+/// Submission response indicating whether the aggregate signature is now complete
+///
+/// # Errors
+///
+/// Returns error if:
+/// - Authentication fails
+/// - Backend returns non-200 status
+/// - Response is malformed
+pub async fn submit_signature(
+    backend_url: &str,
+    file_path: &str,
+    public_key: &AsfaloadPublicKeys,
+    signature: &features_lib::AsfaloadSignatures,
+    secret_key: &AsfaloadSecretKeys,
+) -> Result<SubmitSignatureResponse> {
+    let url = format!("{}/v1/signatures", backend_url);
+
+    // Build the request
+    let request = SubmitSignatureRequest {
+        file_path: file_path.to_string(),
+        public_key: public_key.to_base64(),
+        signature: signature.to_base64(),
+    };
+
+    // Create auth headers
+    let request_json = serde_json::to_string(&request)
+        .map_err(|e| ClientCliError::InvalidInput(format!("Failed to serialize request: {}", e)))?;
+    let headers = create_auth_headers(&request_json, secret_key.clone())?;
+
+    let client = Client::new();
+    let response = client
+        .post(&url)
+        .headers(headers)
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| ClientCliError::NetworkError(e.to_string()))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(ClientCliError::RequestFailed(format!(
+            "{}: {}",
+            status, error_text
+        )));
+    }
+
+    let response_body: SubmitSignatureResponse = response.json().await.map_err(|e| {
+        ClientCliError::ResponseParseError(format!("Failed to parse response: {}", e))
+    })?;
+
+    Ok(response_body)
+}
+
+/// Register a GitHub release with the backend.
+///
+/// Makes an authenticated POST request to /v1/release endpoint.
+///
+/// # Arguments
+///
+/// * `backend_url` - Base URL of the backend API
+/// * `release_url` - URL of the GitHub release to register
+/// * `secret_key` - The secret key for signing the request
+///
+/// # Returns
+///
+/// Registration response with success status and index file path
+///
+/// # Errors
+///
+/// Returns error if:
+/// - Authentication fails
+/// - Backend returns non-200 status
+/// - Response is malformed
+pub async fn register_release(
+    backend_url: &str,
+    release_url: &str,
+    secret_key: AsfaloadSecretKeys,
+) -> Result<RegisterReleaseResponse> {
+    let url = format!("{}/v1/release", backend_url);
+
+    let payload = serde_json::json!({
+        "release_url": release_url
+    });
+
+    let payload_string = payload.to_string();
+    let headers = create_auth_headers(&payload_string, secret_key)?;
+
+    let client = Client::new();
+    let response = client
+        .post(&url)
+        .headers(headers)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| ClientCliError::NetworkError(e.to_string()))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let error_text = match response.text().await {
+            Ok(text) => text,
+            Err(e) => format!("(could not read response body: {})", e),
+        };
+        return Err(ClientCliError::RequestFailed(format!(
+            "{}: {}",
+            status, error_text
+        )));
+    }
+
+    let response_body: RegisterReleaseResponse = response.json().await.map_err(|e| {
+        ClientCliError::ResponseParseError(format!("Failed to parse response: {}", e))
+    })?;
+
+    Ok(response_body)
+}

--- a/client-lib/src/download.rs
+++ b/client-lib/src/download.rs
@@ -1,102 +1,11 @@
-use crate::backend::{download_file, download_file_to_temp};
-use crate::types::DownloadCallbacks;
-use crate::verification::{get_file_hash_info, verify_file_hash, verify_signatures};
-use crate::{AsfaloadLibResult, ClientLibError, DownloadResult};
-use features_lib::{
-    AsfaloadIndex,
-    constants::{INDEX_FILE, SIGNATURES_SUFFIX},
-    parse_signers_config, sha512_for_content,
-};
-use reqwest::{Client, Url};
-use std::path::PathBuf;
+mod v1;
 
-/// Handle the download command
-pub async fn download_file_with_verification(
-    file_url: &str,
-    output: Option<&PathBuf>,
-    backend_url: &str,
-    callbacks: &DownloadCallbacks,
-) -> AsfaloadLibResult<DownloadResult> {
-    callbacks.emit_starting(file_url);
+use crate::{AsfaloadLibResult, ClientLibError};
+use features_lib::constants::INDEX_FILE;
+use reqwest::Url;
 
-    let client = Client::new();
-
-    let url = Url::parse(file_url).map_err(|e| ClientLibError::InvalidUrl(e.to_string()))?;
-
-    let filename = url
-        .path_segments()
-        .and_then(|mut segments| segments.next_back())
-        .ok_or_else(|| {
-            ClientLibError::InvalidUrl("Could not extract filename from URL".to_string())
-        })?;
-
-    let index_file_path = construct_index_file_path(&url)?;
-
-    let signers_url = format!("{}/get-signers/{}", backend_url, index_file_path);
-    let signers_content =
-        download_file(&client, &signers_url, &DownloadCallbacks::default()).await?;
-    callbacks.emit_signers_downloaded(signers_content.len());
-    let signers_config = parse_signers_config(std::str::from_utf8(&signers_content)?)
-        .map_err(|e| ClientLibError::SignersConfigParse(e.to_string()))?;
-
-    let index_url = format!("{}/files/{}", backend_url, index_file_path);
-    let index_content = download_file(&client, &index_url, &DownloadCallbacks::default()).await?;
-    callbacks.emit_index_downloaded(index_content.len());
-    let index: AsfaloadIndex = serde_json::from_slice(&index_content)?;
-
-    let signatures_file_path =
-        construct_file_repo_path(&url, &format!("{}.{}", INDEX_FILE, SIGNATURES_SUFFIX))?;
-    let signatures_url = format!("{}/files/{}", backend_url, signatures_file_path);
-    let signatures_content =
-        download_file(&client, &signatures_url, &DownloadCallbacks::default()).await?;
-    callbacks.emit_signatures_downloaded(signatures_content.len());
-
-    let file_hash = sha512_for_content(index_content)?;
-
-    let (valid_count, invalid_count) =
-        verify_signatures(signatures_content, &signers_config, &file_hash)?;
-
-    callbacks.emit_signatures_verified(valid_count, invalid_count);
-
-    // Get expected hash from index (validates algorithm is supported)
-    let expected_hash = get_file_hash_info(&index, filename)?;
-
-    callbacks.emit_file_download_started(filename, None);
-
-    // Download file to temp location with incremental hash computation
-    let (temp_file, bytes_downloaded, computed_hash) =
-        download_file_to_temp(&client, file_url, &expected_hash.algorithm(), callbacks).await?;
-
-    callbacks.emit_file_download_completed(bytes_downloaded);
-
-    // Verify hash (algorithm + value)
-    verify_file_hash(&expected_hash, &computed_hash)?;
-
-    callbacks.emit_file_hash_verified(computed_hash.algorithm());
-
-    // Move temp file to final destination (only happens if hash verification succeeded)
-    let output_path = output.cloned().unwrap_or_else(|| PathBuf::from(filename));
-    temp_file.persist(&output_path).map_err(|e| {
-        ClientLibError::PersistError(format!(
-            "Failed to move temp file to {:?}: {}",
-            output_path, e
-        ))
-    })?;
-
-    callbacks.emit_file_saved(&output_path);
-
-    let result = DownloadResult {
-        file_path: output_path,
-        bytes_downloaded,
-        signatures_verified: valid_count,
-        signatures_invalid: invalid_count,
-        computed_hash,
-    };
-
-    callbacks.emit_completed(&result);
-
-    Ok(result)
-}
+// Re-export v1's download function as the current API surface
+pub use v1::download_file_with_verification;
 
 fn construct_index_file_path(file_url: &Url) -> AsfaloadLibResult<String> {
     construct_file_repo_path(file_url, INDEX_FILE)

--- a/client-lib/src/download/v1.rs
+++ b/client-lib/src/download/v1.rs
@@ -1,0 +1,101 @@
+use crate::backend::{download_file, download_file_to_temp};
+use crate::types::DownloadCallbacks;
+use crate::verification::{get_file_hash_info, verify_file_hash, verify_signatures};
+use crate::{AsfaloadLibResult, ClientLibError, DownloadResult};
+use features_lib::{
+    AsfaloadIndex,
+    constants::{INDEX_FILE, SIGNATURES_SUFFIX},
+    parse_signers_config, sha512_for_content,
+};
+use reqwest::{Client, Url};
+use std::path::PathBuf;
+
+use super::{construct_file_repo_path, construct_index_file_path};
+
+/// Handle the download command
+pub async fn download_file_with_verification(
+    file_url: &str,
+    output: Option<&PathBuf>,
+    backend_url: &str,
+    callbacks: &DownloadCallbacks,
+) -> AsfaloadLibResult<DownloadResult> {
+    callbacks.emit_starting(file_url);
+
+    let client = Client::new();
+
+    let url = Url::parse(file_url).map_err(|e| ClientLibError::InvalidUrl(e.to_string()))?;
+
+    let filename = url
+        .path_segments()
+        .and_then(|mut segments| segments.next_back())
+        .ok_or_else(|| {
+            ClientLibError::InvalidUrl("Could not extract filename from URL".to_string())
+        })?;
+
+    let index_file_path = construct_index_file_path(&url)?;
+
+    let signers_url = format!("{}/v1/get-signers/{}", backend_url, index_file_path);
+    let signers_content =
+        download_file(&client, &signers_url, &DownloadCallbacks::default()).await?;
+    callbacks.emit_signers_downloaded(signers_content.len());
+    let signers_config = parse_signers_config(std::str::from_utf8(&signers_content)?)
+        .map_err(|e| ClientLibError::SignersConfigParse(e.to_string()))?;
+
+    let index_url = format!("{}/v1/files/{}", backend_url, index_file_path);
+    let index_content = download_file(&client, &index_url, &DownloadCallbacks::default()).await?;
+    callbacks.emit_index_downloaded(index_content.len());
+    let index: AsfaloadIndex = serde_json::from_slice(&index_content)?;
+
+    let signatures_file_path =
+        construct_file_repo_path(&url, &format!("{}.{}", INDEX_FILE, SIGNATURES_SUFFIX))?;
+    let signatures_url = format!("{}/v1/files/{}", backend_url, signatures_file_path);
+    let signatures_content =
+        download_file(&client, &signatures_url, &DownloadCallbacks::default()).await?;
+    callbacks.emit_signatures_downloaded(signatures_content.len());
+
+    let file_hash = sha512_for_content(index_content)?;
+
+    let (valid_count, invalid_count) =
+        verify_signatures(signatures_content, &signers_config, &file_hash)?;
+
+    callbacks.emit_signatures_verified(valid_count, invalid_count);
+
+    // Get expected hash from index (validates algorithm is supported)
+    let expected_hash = get_file_hash_info(&index, filename)?;
+
+    callbacks.emit_file_download_started(filename, None);
+
+    // Download file to temp location with incremental hash computation
+    let (temp_file, bytes_downloaded, computed_hash) =
+        download_file_to_temp(&client, file_url, &expected_hash.algorithm(), callbacks).await?;
+
+    callbacks.emit_file_download_completed(bytes_downloaded);
+
+    // Verify hash (algorithm + value)
+    verify_file_hash(&expected_hash, &computed_hash)?;
+
+    callbacks.emit_file_hash_verified(computed_hash.algorithm());
+
+    // Move temp file to final destination (only happens if hash verification succeeded)
+    let output_path = output.cloned().unwrap_or_else(|| PathBuf::from(filename));
+    temp_file.persist(&output_path).map_err(|e| {
+        ClientLibError::PersistError(format!(
+            "Failed to move temp file to {:?}: {}",
+            output_path, e
+        ))
+    })?;
+
+    callbacks.emit_file_saved(&output_path);
+
+    let result = DownloadResult {
+        file_path: output_path,
+        bytes_downloaded,
+        signatures_verified: valid_count,
+        signatures_invalid: invalid_count,
+        computed_hash,
+    };
+
+    callbacks.emit_completed(&result);
+
+    Ok(result)
+}

--- a/rest-api/src/handlers.rs
+++ b/rest-api/src/handlers.rs
@@ -261,7 +261,7 @@ pub async fn register_repo_handler(
         project_id: signers_proposal.project_id,
         message: "Project registered successfully. Collect signatures to activate.".to_string(),
         required_signers: init_result.required_signers.into_iter().collect(),
-        signature_submission_url: "/signatures".to_string(),
+        signature_submission_url: "/v1/signatures".to_string(),
     }))
 }
 

--- a/rest-api/src/lib.rs
+++ b/rest-api/src/lib.rs
@@ -10,3 +10,4 @@ pub mod pending_discovery;
 pub mod server;
 pub mod state;
 pub mod traces;
+pub mod v1;

--- a/rest-api/src/v1.rs
+++ b/rest-api/src/v1.rs
@@ -1,0 +1,1 @@
+pub mod routes;

--- a/rest-api/src/v1/routes.rs
+++ b/rest-api/src/v1/routes.rs
@@ -1,0 +1,47 @@
+use axum::{
+    Router,
+    routing::{get, post},
+};
+
+use crate::{
+    auth_middleware::auth_middleware,
+    handlers::{
+        add_file_handler, get_file_handler, get_pending_signatures_handler,
+        get_signature_status_handler, get_signers_handler, register_release_handler,
+        register_repo_handler, submit_signature_handler,
+    },
+    state::AppState,
+};
+
+/// Build the v1 API router with all route definitions.
+pub fn v1_router(app_state: AppState) -> Router<AppState> {
+    let register_router = Router::new().route("/register_repo", post(register_repo_handler));
+    let release_router = Router::new()
+        .route("/release", post(register_release_handler))
+        .layer(axum::middleware::from_fn_with_state(
+            app_state.clone(),
+            auth_middleware,
+        ));
+    let add_file_router = Router::new()
+        .route("/add-file", post(add_file_handler))
+        .route("/pending_signatures", get(get_pending_signatures_handler))
+        .layer(axum::middleware::from_fn_with_state(
+            app_state.clone(),
+            auth_middleware,
+        ));
+    let signature_router = Router::new()
+        .route("/signatures", post(submit_signature_handler))
+        .route(
+            "/signatures/{*file_path}",
+            get(get_signature_status_handler),
+        );
+    let files_router = Router::new().route("/files/{*file_path}", get(get_file_handler));
+    let signers_router = Router::new().route("/get-signers/{*file_path}", get(get_signers_handler));
+
+    register_router
+        .merge(release_router)
+        .merge(add_file_router)
+        .merge(signature_router)
+        .merge(files_router)
+        .merge(signers_router)
+}

--- a/rest-api/tests/files_endpoint_test.rs
+++ b/rest-api/tests/files_endpoint_test.rs
@@ -30,7 +30,7 @@ async fn test_get_file_success() -> Result<()> {
     let client = Client::new();
     let response = client
         .get(format!(
-            "http://127.0.0.1:{}/files/{}",
+            "http://127.0.0.1:{}/v1/files/{}",
             port, test_file_path
         ))
         .send()
@@ -101,7 +101,7 @@ async fn test_get_file_path_traversal_blocked() -> Result<()> {
     // Attempt path traversal
     let client = Client::new();
     let response = client
-        .get(format!("http://127.0.0.1:{}/files/../secret.txt", port))
+        .get(format!("http://127.0.0.1:{}/v1/files/../secret.txt", port))
         .send()
         .await?;
 
@@ -110,8 +110,9 @@ async fn test_get_file_path_traversal_blocked() -> Result<()> {
     assert_eq!(response.status(), 404, "Path traversal should be blocked");
     // We test the url returned to detect any change of behaviour in Axum
     // As you see, axum sanitises the input, removing the ..
+    // With /v1/files/../secret.txt, the .. resolves to /v1/secret.txt
     use regex::Regex;
-    let re = Regex::new(r"http://127.0.0.1:\d+/secret.txt").unwrap();
+    let re = Regex::new(r"http://127.0.0.1:\d+/v1/secret.txt").unwrap();
     assert!(re.is_match(response.url().as_str()));
     // Cleanup
     server_handle.abort();

--- a/rest-api/tests/integration_pending_workflow.rs
+++ b/rest-api/tests/integration_pending_workflow.rs
@@ -81,7 +81,7 @@ async fn test_pending_workflow_end_to_end() -> Result<()> {
     let auth_signature1 = AuthSignature::new(&auth_info1, &secret_key1)?;
 
     let response1 = client
-        .get(format!("http://127.0.0.1:{}/pending_signatures", port))
+        .get(format!("http://127.0.0.1:{}/v1/pending_signatures", port))
         .header(
             HEADER_TIMESTAMP,
             auth_signature1.auth_info().timestamp().to_rfc3339(),
@@ -116,7 +116,7 @@ async fn test_pending_workflow_end_to_end() -> Result<()> {
     let auth_signature2 = AuthSignature::new(&auth_info2, &secret_key1)?;
 
     let response2 = client
-        .post(format!("http://127.0.0.1:{}/signatures", port))
+        .post(format!("http://127.0.0.1:{}/v1/signatures", port))
         .header(
             HEADER_TIMESTAMP,
             auth_signature2.auth_info().timestamp().to_rfc3339(),
@@ -141,7 +141,7 @@ async fn test_pending_workflow_end_to_end() -> Result<()> {
     let auth_signature3 = AuthSignature::new(&auth_info3, &secret_key1)?;
 
     let response3 = client
-        .get(format!("http://127.0.0.1:{}/pending_signatures", port))
+        .get(format!("http://127.0.0.1:{}/v1/pending_signatures", port))
         .header(
             HEADER_TIMESTAMP,
             auth_signature3.auth_info().timestamp().to_rfc3339(),
@@ -167,7 +167,7 @@ async fn test_pending_workflow_end_to_end() -> Result<()> {
     let auth_signature4 = AuthSignature::new(&auth_info4, &secret_key2)?;
 
     let response4 = client
-        .get(format!("http://127.0.0.1:{}/pending_signatures", port))
+        .get(format!("http://127.0.0.1:{}/v1/pending_signatures", port))
         .header(
             HEADER_TIMESTAMP,
             auth_signature4.auth_info().timestamp().to_rfc3339(),

--- a/rest_api_test_helpers/src/lib.rs
+++ b/rest_api_test_helpers/src/lib.rs
@@ -101,7 +101,7 @@ pub async fn get_random_port() -> Result<u16, ApiError> {
 }
 
 pub fn url_for(action: &str, port: u16) -> String {
-    format!("http://localhost:{port}/{action}")
+    format!("http://localhost:{port}/v1/{action}")
 }
 
 /// Helper function to build a test config


### PR DESCRIPTION
add /v1 prefix to endpoints. Route definitions are extracted into rest-api/src/v1/routes.rs and nested via Router::nest("/v1", …), keeping handlers and middleware shared.