### PR TITLE
docs(client-cli): add how-to guides for all CLI operations

### DIFF
--- a/client-cli/docs/howto/activate-signers-file.md
+++ b/client-cli/docs/howto/activate-signers-file.md
@@ -1,0 +1,93 @@
+# Activate a signers file
+
+After a repository is registered (or a signers file is updated), the signers file sits in a **pending** state. Every signer listed in it must sign before the project becomes active. This guide covers the signing round.
+
+## Prerequisites
+
+- A repository has been [registered](register-repo.md) or a signers file [update proposed](update-signers-file.md).
+- Each signer has their own secret key. See [Generate a key pair](generate-keys.md).
+
+## Steps
+
+Each signer performs steps 1–2 independently.
+
+### 1. Check for pending work
+
+```sh
+client list-pending --secret-key ~/.asfaload/mykey
+```
+
+If the signers file is waiting for your signature, you'll see:
+
+```
+Files requiring your signature:
+  - https/github.com/443/acme/tool/asfaload.signers.pending/index.json
+```
+
+If nothing is pending for you, the output says `No pending signatures found.`
+
+### 2. Sign the pending signers file
+
+Copy the path from the output above and pass it to `sign-pending`:
+
+```sh
+client sign-pending --secret-key ~/.asfaload/mykey \
+    https/github.com/443/acme/tool/asfaload.signers.pending/index.json
+```
+
+If more signatures are needed:
+
+```
+Success! Signature submitted
+```
+
+When your signature completes the required count (every signer must sign for an initial signers file):
+
+```
+Success! Signature submitted (complete)
+```
+
+### 3. Verify activation
+
+Once every signer has signed, the signers file moves from pending to active. There is no separate activation step — the last signature triggers it automatically.
+
+## Coordinating signers
+
+Signers don't need to sign in any particular order. The workflow looks like:
+
+```
+alice: client list-pending -K alice.key    → sees pending signers
+alice: client sign-pending -K alice.key ...  → "submitted"
+
+bob:   client list-pending -K bob.key      → sees pending signers
+bob:   client sign-pending -K bob.key ...    → "submitted"
+
+carol: client list-pending -K carol.key    → sees pending signers
+carol: client sign-pending -K carol.key ...  → "submitted (complete)"
+```
+
+## Scripting the sign step
+
+For CI, supply the password non-interactively:
+
+```sh
+client sign-pending \
+    --secret-key ~/.asfaload/mykey \
+    --password "$KEY_PASSWORD" \
+    https/github.com/443/acme/tool/asfaload.signers.pending/index.json
+```
+
+## Troubleshooting
+
+**"Already completed" error when signing** — someone else already provided the final signature. The signers file is active; no action needed.
+
+**list-pending returns empty** — either your key is not listed in the signers file, or the file has already been fully signed.
+
+## Next step
+
+Once the signers file is active, you can [register a release](register-release.md) for signing.
+
+## Reference
+
+- [`client list-pending`](../manual/list-pending.md)
+- [`client sign-pending`](../manual/sign-pending.md)

--- a/client-cli/docs/howto/activate-signers-file.md
+++ b/client-cli/docs/howto/activate-signers-file.md
@@ -56,14 +56,14 @@ Once every signer has signed, the signers file moves from pending to active. The
 Signers don't need to sign in any particular order. The workflow looks like:
 
 ```
-alice: client list-pending -K alice.key    → sees pending signers
-alice: client sign-pending -K alice.key ...  → "submitted"
+alice: client list-pending --secret-key alice.key    → sees pending signers
+alice: client sign-pending --secret-key alice.key ...  → "submitted"
 
-bob:   client list-pending -K bob.key      → sees pending signers
-bob:   client sign-pending -K bob.key ...    → "submitted"
+bob:   client list-pending --secret-key bob.key      → sees pending signers
+bob:   client sign-pending --secret-key bob.key ...    → "submitted"
 
-carol: client list-pending -K carol.key    → sees pending signers
-carol: client sign-pending -K carol.key ...  → "submitted (complete)"
+carol: client list-pending --secret-key carol.key    → sees pending signers
+carol: client sign-pending --secret-key carol.key ...  → "submitted (complete)"
 ```
 
 ## Scripting the sign step

--- a/client-cli/docs/howto/create-signers-file.md
+++ b/client-cli/docs/howto/create-signers-file.md
@@ -41,7 +41,10 @@ Master keys: 0 (threshold: none)
 
 ### 3. Commit and push
 
-Place the signers file in your repository and push it. The backend needs to fetch it by URL during [repository registration](register-repo.md).
+Place the signers file in your repository and push it.
+We advise to commit the file in your main branch (eg under a directory .asfaload.signers) or in a dedicated branch of the repo.
+The best is to not update existing signers files but add a new version alongside it.
+The backend needs to fetch it by URL during [repository registration](register-repo.md).
 
 A common location is at the root of your repo:
 

--- a/client-cli/docs/howto/create-signers-file.md
+++ b/client-cli/docs/howto/create-signers-file.md
@@ -1,0 +1,109 @@
+# Create a signers file
+
+A signers file defines who can sign artifacts for your project, and how many signatures are needed (the threshold). You create it once, commit it to your repository, then register it with the backend.
+
+## Prerequisites
+
+- Public key files (`.pub`) for every signer. See [Generate a key pair](generate-keys.md).
+- A target repository where the signers file will live.
+
+## Steps
+
+### 1. Collect the public keys
+
+Gather `.pub` files from all signers. For this example, three artifact signers with a threshold of 2 (any two out of three must sign):
+
+```
+alice.pub
+bob.pub
+carol.pub
+```
+
+### 2. Create the signers file
+
+```sh
+client new-signers-file \
+    --artifact-signer-file alice.pub \
+    --artifact-signer-file bob.pub \
+    --artifact-signer-file carol.pub \
+    --artifact-threshold 2 \
+    --output-file signers.json
+```
+
+The command prints a summary:
+
+```
+Signers file created successfully at: "signers.json"
+Artifact signers: 3 (threshold: 2)
+Admin keys: 0 (threshold: none)
+Master keys: 0 (threshold: none)
+```
+
+### 3. Commit and push
+
+Place the signers file in your repository and push it. The backend needs to fetch it by URL during [repository registration](register-repo.md).
+
+A common location is at the root of your repo:
+
+```sh
+cp signers.json my-project/asfaload.signers/index.json
+cd my-project
+git add asfaload.signers/index.json
+git commit -m "Add asfaload signers file"
+git push
+```
+
+## Adding optional key groups
+
+Beyond artifact signers, you can define admin, master, and revocation key groups. Each group has its own keys and threshold.
+
+### With revocation keys
+
+Revocation keys can revoke signed releases. Useful to have a separate set of keys for emergency access:
+
+```sh
+client new-signers-file \
+    --artifact-signer-file alice.pub \
+    --artifact-signer-file bob.pub \
+    --artifact-signer-file carol.pub \
+    --artifact-threshold 2 \
+    --revocation-key-file revoke1.pub \
+    --revocation-key-file revoke2.pub \
+    --revocation-key-file revoke3.pub \
+    --revocation-threshold 2 \
+    --output-file signers.json
+```
+
+### With admin keys
+
+Admin keys can propose signers file updates:
+
+```sh
+client new-signers-file \
+    --artifact-signer-file alice.pub \
+    --artifact-signer-file bob.pub \
+    --artifact-threshold 2 \
+    --admin-key-file admin.pub \
+    --admin-threshold 1 \
+    --output-file signers.json
+```
+
+## Mixing base64 strings and files
+
+You can pass public keys as base64 strings instead of files. This is handy when keys come from a secrets manager:
+
+```sh
+client new-signers-file \
+    --artifact-signer "minisign:RWQwtmTQyX/sEi37..." \
+    --artifact-signer-file bob.pub \
+    --artifact-threshold 1 \
+    --output-file signers.json
+```
+
+## Next step
+
+[Register the repository](register-repo.md) with the backend so it knows where to find your signers file.
+
+## Reference
+
+- [`client new-signers-file`](../manual/new-signers-file.md)

--- a/client-cli/docs/howto/download-with-verification.md
+++ b/client-cli/docs/howto/download-with-verification.md
@@ -1,0 +1,92 @@
+# Download a file with signature verification
+
+The `download` command fetches a file and verifies its signatures before saving it to disk. If the signatures don't check out, or the file has been revoked, the download is aborted.
+
+## Prerequisites
+
+- The file has been signed on the backend (signatures meet the threshold).
+- The backend is running and reachable.
+
+## Steps
+
+### 1. Download a release artifact
+
+Pass the original download URL — the same URL you'd use to download from GitHub or your forge:
+
+```sh
+client download \
+    https://github.com/acme/tool/releases/download/v1.0/tool-linux-amd64.tar.gz
+```
+
+The command prints each verification step:
+
+```
+Starting download: https://github.com/acme/tool/releases/download/v1.0/tool-linux-amd64.tar.gz
+✓ Downloaded signers file (1234 bytes)
+✓ Downloaded index file (567 bytes)
+✓ Downloaded signatures file (890 bytes)
+✓ Signatures verified successfully (2 valid)
+Downloading tool-linux-amd64.tar.gz
+  Size: 12.50 MB
+Progress: 100.0% (12.50 MB / 12.50 MB)
+✓ Download complete (12.50 MB)
+✓ File hash verified (SHA-256)
+✓ File saved to: ./tool-linux-amd64.tar.gz
+✓ All done! Verified 2 signature(s)
+```
+
+### 2. Choose where to save
+
+By default, the file is saved in the current directory using the filename from the URL. Use `-o` to specify a different path:
+
+```sh
+client download -o /tmp/tool.tar.gz \
+    https://github.com/acme/tool/releases/download/v1.0/tool-linux-amd64.tar.gz
+```
+
+## Full signers chain verification
+
+By default, only the current signers file is verified. For stronger assurance — especially if the signers file has been updated since the release was signed — use `--full-check`:
+
+```sh
+client download --full-check \
+    https://github.com/acme/tool/releases/download/v1.0/tool-linux-amd64.tar.gz
+```
+
+This walks the full signers chain history and verifies each entry against the forge, catching tampering in historical signers files. You'll see an additional verification line:
+
+```
+✓ Signers chain history verified (3 entries)
+```
+
+## Overriding forge detection
+
+The CLI auto-detects the forge type from the URL. If detection fails or you're using a generic file server:
+
+```sh
+client download --type fileserver \
+    https://files.example.com/tool/v1.0/tool.tar.gz
+```
+
+Available types: `github`, `gitlab`, `fileserver`.
+
+## Pointing to a non-default backend
+
+```sh
+client download -u https://asfaload.example.com \
+    https://github.com/acme/tool/releases/download/v1.0/tool-linux-amd64.tar.gz
+```
+
+## What happens with revoked files
+
+If the file has been [revoked](revoke-release.md), the download fails:
+
+```
+This file has been revoked.
+  Revoked at: 2025-03-15T10:30:00Z
+  Revoked by: minisign:RWQwtmTQyX/sEi37...
+```
+
+## Reference
+
+- [`client download`](../manual/download.md)

--- a/client-cli/docs/howto/generate-keys.md
+++ b/client-cli/docs/howto/generate-keys.md
@@ -1,0 +1,73 @@
+# Generate a key pair
+
+Every signer needs their own key pair. This guide walks you through creating one.
+
+## Prerequisites
+
+- The `client` binary is installed and in your `PATH`.
+
+## Steps
+
+### 1. Choose a directory
+
+Pick a directory to store your keys. A common convention is `~/.asfaload/`:
+
+```sh
+mkdir -p ~/.asfaload
+```
+
+### 2. Generate the key pair
+
+```sh
+client new-keys --name mykey --output-dir ~/.asfaload
+```
+
+You'll be prompted for a password to protect the secret key. Pick a strong one — this password is required every time you sign.
+
+This creates two files:
+
+| File | Purpose |
+|------|---------|
+| `~/.asfaload/mykey` | Secret key (keep this safe) |
+| `~/.asfaload/mykey.pub` | Public key (share with your team) |
+
+### 3. Verify the output
+
+```sh
+ls ~/.asfaload/mykey*
+```
+
+You should see both `mykey` and `mykey.pub`.
+
+## Choosing an algorithm
+
+The default algorithm is `minisign`. If your project requires Ed25519 keys:
+
+```sh
+client new-keys --name mykey --output-dir ~/.asfaload --algorithm ed25519
+```
+
+All signers in the same signers file must use the same algorithm.
+
+## Non-interactive usage
+
+For CI or scripting, pass the password directly:
+
+```sh
+client new-keys --name ci-key --output-dir ./keys --password "$KEY_PASSWORD"
+```
+
+Or via environment variable:
+
+```sh
+export ASFALOAD_NEW_KEYS_PASSWORD="$KEY_PASSWORD"
+client new-keys --name ci-key --output-dir ./keys
+```
+
+## Next step
+
+Share your `.pub` file with whoever maintains the signers file. They'll include it when [creating the signers file](create-signers-file.md).
+
+## Reference
+
+- [`client new-keys`](../manual/new-keys.md)

--- a/client-cli/docs/howto/index.md
+++ b/client-cli/docs/howto/index.md
@@ -1,0 +1,27 @@
+# How-to guides
+
+Step-by-step recipes for common operations with the `client` CLI. Follow them in order for a first-time setup, or jump to the one you need.
+
+## Setup
+
+1. [Generate a key pair](generate-keys.md)
+2. [Create a signers file](create-signers-file.md)
+
+## Project registration
+
+3. [Register a repository](register-repo.md)
+4. [Activate a signers file](activate-signers-file.md)
+
+## Releases
+
+5. [Register a release](register-release.md)
+6. [Sign a release](sign-release.md)
+
+## Maintenance
+
+7. [Update a signers file](update-signers-file.md)
+8. [Revoke a signed release](revoke-release.md)
+
+## Verification
+
+9. [Download a file with signature verification](download-with-verification.md)

--- a/client-cli/docs/howto/register-release.md
+++ b/client-cli/docs/howto/register-release.md
@@ -1,0 +1,53 @@
+# Register a release
+
+Once your project's signers file is active, you can register releases for signing. The backend will index the release assets and start a signature collection round.
+
+## Prerequisites
+
+- The repository is registered and the signers file is [activated](activate-signers-file.md).
+- The release is published on the forge (e.g., a GitHub release page exists).
+- Your secret key file. See [Generate a key pair](generate-keys.md).
+
+## Register a GitHub release
+
+Pass the release page URL:
+
+```sh
+client register-assets \
+    --secret-key ~/.asfaload/mykey \
+    --github-release-url https://github.com/acme/tool/releases/tag/v1.0
+```
+
+On success:
+
+```
+Assets registered successfully! Remember you still need to sign it yourself!
+Index file path: https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json
+```
+
+The backend fetches the release, creates an index of the assets, and waits for signatures.
+
+## Register checksum files
+
+If your release uses checksum files instead of a GitHub release:
+
+```sh
+client register-assets \
+    --secret-key ~/.asfaload/mykey \
+    --csum-file https://example.com/releases/v1.0/SHA256SUMS \
+    --csum-file https://example.com/releases/v1.0/SHA512SUMS
+```
+
+All checksum file URLs must share a common parent path. `--csum-file` is repeatable; `--github-release-url` and `--csum-file` are mutually exclusive.
+
+## Re-registration
+
+Registering the same release twice fails — the backend rejects duplicates. Existing signatures are preserved; there's no risk of losing progress.
+
+## What happens next
+
+You registered the release, but you haven't signed it yet. The backend is now waiting for enough signatures to meet the threshold. See [Sign a release](sign-release.md).
+
+## Reference
+
+- [`client register-assets`](../manual/register-assets.md)

--- a/client-cli/docs/howto/register-repo.md
+++ b/client-cli/docs/howto/register-repo.md
@@ -1,0 +1,57 @@
+# Register a repository
+
+Registering a repository tells the backend where your signers file lives. Once registered, the backend can enforce signature requirements for your project.
+
+## Prerequisites
+
+- A signers file committed and pushed to your repository. See [Create a signers file](create-signers-file.md).
+- Your secret key file. See [Generate a key pair](generate-keys.md).
+- The backend is running and reachable.
+
+## Steps
+
+### 1. Get the signers file URL
+
+You need the public URL that points to your signers file on the forge. For GitHub:
+
+```
+https://github.com/acme/tool/blob/main/asfaload.signers/index.json
+```
+
+### 2. Register the repository
+
+```sh
+client register-repo \
+    --secret-key ~/.asfaload/mykey \
+    https://github.com/acme/tool/blob/main/asfaload.signers/index.json
+```
+
+On success:
+
+```
+Repository registered successfully!
+Project ID: abc123
+Required signers (3): alice, bob, carol
+Next step: signers must submit signatures to activate the project.
+```
+
+The backend fetches the signers file, creates a pending signers entry, and waits for **all** listed signers to sign before the project becomes active.
+
+### 3. Point to a non-default backend
+
+If your backend is not at `http://127.0.0.1:3000`:
+
+```sh
+client register-repo \
+    --secret-key ~/.asfaload/mykey \
+    -u https://asfaload.example.com \
+    https://github.com/acme/tool/blob/main/asfaload.signers/index.json
+```
+
+## What happens next
+
+After registration, the signers file is in a **pending** state. Every signer listed in it must sign before the project is activated. See [Activate a signers file](activate-signers-file.md).
+
+## Reference
+
+- [`client register-repo`](../manual/register-repo.md)

--- a/client-cli/docs/howto/revoke-release.md
+++ b/client-cli/docs/howto/revoke-release.md
@@ -1,0 +1,79 @@
+# Revoke a signed release
+
+If a release needs to be recalled — a vulnerability was found, or the wrong artifacts were published — you can revoke it. Revoked files can no longer be downloaded with verification.
+
+## Prerequisites
+
+- The release is fully signed and active on the backend.
+- Your key is listed as a **revocation key** in the active signers file. Artifact signers without revocation privileges cannot revoke.
+- The signers file has a revocation group with a threshold. See [Create a signers file](create-signers-file.md).
+
+## Steps
+
+### 1. Initiate the revocation
+
+```sh
+client revoke \
+    --secret-key ~/.asfaload/revoke-key \
+    https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json
+```
+
+On success:
+
+```
+Success! File revoked: https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json
+```
+
+If the revocation threshold is 1, the file is revoked immediately. If the threshold is higher, the revocation enters a **pending** state and more revocation signers must co-sign.
+
+### 2. Co-sign the revocation (if threshold > 1)
+
+When the revocation threshold requires multiple signatures, additional revocation signers use `list-pending` and `sign-pending` to add their signatures:
+
+```sh
+# Another revocation signer checks for pending work
+client list-pending --secret-key ~/.asfaload/revoke-key-2
+```
+
+The pending revocation shows up as a path ending in `.revocation.json.pending`:
+
+```
+Files requiring your signature:
+  - https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json.revocation.json.pending
+```
+
+Sign it:
+
+```sh
+client sign-pending --secret-key ~/.asfaload/revoke-key-2 \
+    https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json.revocation.json.pending
+```
+
+Once the threshold is met, the revocation is finalized.
+
+### 3. Verify the revocation
+
+Attempting to download a revoked file fails:
+
+```sh
+client download https://github.com/acme/tool/releases/download/v1.0/artifact.bin
+```
+
+```
+This file has been revoked.
+  Revoked at: 2025-03-15T10:30:00Z
+  Revoked by: minisign:RWQwtmTQyX/sEi37...
+```
+
+## Important notes
+
+- **Only revocation keys can revoke.** Artifact signers listed in the `artifact_signers` group cannot initiate or co-sign a revocation.
+- **Revocation is irreversible.** Once a file is revoked, it stays revoked.
+- **Other releases are unaffected.** Revoking v1.0 does not impact v2.0.
+- **Re-initiating a pending revocation fails.** If a revocation is already pending, starting another one for the same file is rejected.
+
+## Reference
+
+- [`client revoke`](../manual/revoke.md)
+- [`client list-pending`](../manual/list-pending.md)
+- [`client sign-pending`](../manual/sign-pending.md)

--- a/client-cli/docs/howto/sign-release.md
+++ b/client-cli/docs/howto/sign-release.md
@@ -1,0 +1,81 @@
+# Sign a release
+
+After a release is [registered](register-release.md), artifact signers must provide enough signatures to meet the threshold defined in the signers file. This is the same `list-pending` / `sign-pending` flow used for [activating a signers file](activate-signers-file.md), but applied to a release index.
+
+## Prerequisites
+
+- A release has been [registered](register-release.md).
+- Your key is listed as an artifact signer in the active signers file.
+
+## Steps
+
+### 1. List pending files
+
+```sh
+client list-pending --secret-key ~/.asfaload/mykey
+```
+
+```
+Files requiring your signature:
+  - https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json
+```
+
+### 2. Sign the release index
+
+```sh
+client sign-pending --secret-key ~/.asfaload/mykey \
+    https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json
+```
+
+The command fetches all files associated with the release, hashes each one, signs the hashes, and submits everything in a single request.
+
+If more signatures are needed:
+
+```
+Success! Signature submitted
+```
+
+When the threshold is met:
+
+```
+Success! Signature submitted (complete)
+```
+
+### 3. Check progress
+
+At any point, you can check whether the threshold has been reached:
+
+```sh
+client signature-status --secret-key ~/.asfaload/mykey \
+    https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json
+```
+
+```
+https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json: pending
+```
+
+or
+
+```
+https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json: complete
+```
+
+## Example: two-of-three threshold
+
+With three artifact signers and a threshold of 2, only two need to sign:
+
+```
+alice: client sign-pending -K alice.key ...  → "submitted"
+bob:   client sign-pending -K bob.key ...    → "submitted (complete)"
+# carol doesn't need to sign — threshold already met
+```
+
+## Next step
+
+Once the release is fully signed, users can [download it with verification](download-with-verification.md).
+
+## Reference
+
+- [`client list-pending`](../manual/list-pending.md)
+- [`client sign-pending`](../manual/sign-pending.md)
+- [`client signature-status`](../manual/signature-status.md)

--- a/client-cli/docs/howto/sign-release.md
+++ b/client-cli/docs/howto/sign-release.md
@@ -65,8 +65,8 @@ https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json: complete
 With three artifact signers and a threshold of 2, only two need to sign:
 
 ```
-alice: client sign-pending -K alice.key ...  → "submitted"
-bob:   client sign-pending -K bob.key ...    → "submitted (complete)"
+alice: client sign-pending --secret-key alice.key ...  → "submitted"
+bob:   client sign-pending --secret-key bob.key ...    → "submitted (complete)"
 # carol doesn't need to sign — threshold already met
 ```
 

--- a/client-cli/docs/howto/update-signers-file.md
+++ b/client-cli/docs/howto/update-signers-file.md
@@ -29,6 +29,7 @@ client new-signers-file \
 ```
 
 Commit and push it to your repository so the backend can fetch it by URL.
+We advise to commit the file either in your main branch, or in a dedicated branch in which you save all signers files updates.
 
 ### 2. Propose the update
 

--- a/client-cli/docs/howto/update-signers-file.md
+++ b/client-cli/docs/howto/update-signers-file.md
@@ -1,0 +1,71 @@
+# Update a signers file
+
+Need to add a signer, remove one, or change the threshold? This guide covers proposing and activating a signers file update.
+
+## Prerequisites
+
+- The repository is already registered and the current signers file is active.
+- A new signers file has been created (see [Create a signers file](create-signers-file.md)), committed, and pushed to the forge.
+- Your secret key file. See [Generate a key pair](generate-keys.md).
+
+## Steps
+
+### 1. Create and push the new signers file
+
+Generate a new signers file with the updated set of keys and thresholds:
+
+```sh
+client new-signers-file \
+    --artifact-signer-file alice.pub \
+    --artifact-signer-file bob.pub \
+    --artifact-signer-file carol.pub \
+    --artifact-signer-file dave.pub \
+    --artifact-threshold 3 \
+    --revocation-key-file revoke1.pub \
+    --revocation-key-file revoke2.pub \
+    --revocation-key-file revoke3.pub \
+    --revocation-threshold 2 \
+    --output-file signers_v2.json
+```
+
+Commit and push it to your repository so the backend can fetch it by URL.
+
+### 2. Propose the update
+
+```sh
+client update-signers \
+    --secret-key ~/.asfaload/mykey \
+    https://github.com/acme/tool/blob/main/asfaload.signers/index.json
+```
+
+On success:
+
+```
+Signers update proposed successfully!
+Project ID: abc123
+Required signers (4): alice, bob, carol, dave
+Next step: signers must submit signatures to activate the update.
+```
+
+### 3. All signers must sign
+
+Just like initial activation, **every** signer listed in the **new** signers file must sign before the update takes effect. This includes both existing and newly added signers.
+
+Each signer runs:
+
+```sh
+client list-pending --secret-key ~/.asfaload/mykey
+client sign-pending --secret-key ~/.asfaload/mykey \
+    https/github.com/443/acme/tool/asfaload.signers.pending/index.json
+```
+
+See [Activate a signers file](activate-signers-file.md) for the full signing flow.
+
+## What about existing releases?
+
+Releases signed under the **previous** signers file remain valid. The backend keeps a signers chain history, so older releases can still be verified against the signers file that was active when they were signed.
+
+## Reference
+
+- [`client new-signers-file`](../manual/new-signers-file.md)
+- [`client update-signers`](../manual/update-signers.md)


### PR DESCRIPTION
Cover the full signing workflow as step-by-step recipes: generate keys, create signers file, register repo, activate signers, register release, sign release, update signers, revoke, and download. Each guide links to the next step and back to the reference manual.