### PR TITLE
docs(client-cli): add manual pages for all commands

### DIFF
--- a/client-cli/docs/manual/download.md
+++ b/client-cli/docs/manual/download.md
@@ -1,0 +1,87 @@
+# `client download`
+
+- **Usage**: `client download [OPTIONS] <FILE_URL>`
+- **Source**: [`src/commands/download.rs`](../../src/commands/download.rs)
+
+Download a file and verify its signatures before saving. The command fetches the signers file, index, and signatures from the backend, checks everything is valid, then downloads the actual file and verifies its hash.
+
+If the file has been revoked, a warning is printed to stderr and the download is aborted.
+
+## Arguments
+
+### `<FILE_URL>`
+
+Public URL of the file to download. For example:
+
+    https://github.com/acme/tool/releases/download/v1.0/tool-linux-amd64.tar.gz
+
+## Options
+
+### `-o --output <PATH>`
+
+Output file path. Defaults to the filename extracted from the URL.
+
+### `-u --backend-url <URL>`
+
+Backend API URL. Defaults to `http://127.0.0.1:3000`.
+
+### `--type <FORGE_TYPE>`
+
+Override automatic forge type detection.
+
+| Value | Description |
+|-------|-------------|
+| `github` | GitHub release |
+| `gitlab` | GitLab release |
+| `fileserver` | Generic file server |
+
+### `--full-check`
+
+Verify the full signers chain history during download. Without this flag only the current signers file is checked.
+
+## Output
+
+The command prints progress to stdout as each verification step completes:
+
+    Starting download: https://github.com/acme/tool/releases/download/v1.0/tool.tar.gz
+    ✓ Downloaded signers file (1234 bytes)
+    ✓ Downloaded index file (567 bytes)
+    ✓ Downloaded signatures file (890 bytes)
+    ✓ Signatures verified successfully (2 valid)
+    ✓ Signers chain history verified (3 entries)
+    Downloading tool.tar.gz
+      Size: 12.50 MB
+    Progress: 100.0% (12.50 MB / 12.50 MB)
+    ✓ Download complete (12.50 MB)
+    ✓ File hash verified (SHA-256)
+    ✓ File saved to: ./tool.tar.gz
+    ✓ All done! Verified 2 signature(s)
+
+If the file has been revoked:
+
+    This file has been revoked.
+      Revoked at: 2025-03-15T10:30:00Z
+      Revoked by: minisign:RWQwtmTQyX/sEi37...
+
+## Examples
+
+    # download and verify a release artifact
+    client download \
+        https://github.com/acme/tool/releases/download/v1.0/tool-linux-amd64.tar.gz
+
+    # save to a specific path
+    client download -o /tmp/tool.tar.gz \
+        https://github.com/acme/tool/releases/download/v1.0/tool-linux-amd64.tar.gz
+
+    # verify the full signers chain history
+    client download --full-check \
+        https://github.com/acme/tool/releases/download/v1.0/tool-linux-amd64.tar.gz
+
+    # override forge detection
+    client download --type gitlab \
+        https://gitlab.com/acme/tool/-/releases/v1.0/downloads/tool.tar.gz
+
+## Exit codes
+
+- `0` — download and verification succeeded.
+- non-zero — error (verification failure, revoked file, network error).

--- a/client-cli/docs/manual/index.md
+++ b/client-cli/docs/manual/index.md
@@ -2,6 +2,30 @@
 
 Reference for all `client` commands.
 
+## Keys
+
+- [`new-keys`](new-keys.md) — generate a new signing key pair
+
+## Signers
+
+- [`new-signers-file`](new-signers-file.md) — create a signers file defining authorized keys and thresholds
+- [`update-signers`](update-signers.md) — propose an update to an existing signers file
+
+## Registration
+
+- [`register-repo`](register-repo.md) — register a repository with the backend
+- [`register-assets`](register-assets.md) — register assets (GitHub release or checksum files) for signing
+
 ## Signing
 
+- [`list-pending`](list-pending.md) — list files that still need your signature
+- [`sign-pending`](sign-pending.md) — sign a pending file
 - [`signature-status`](signature-status.md) — check a file's signature collection status
+
+## Revocation
+
+- [`revoke`](revoke.md) — revoke a previously signed file
+
+## Verification
+
+- [`download`](download.md) — download a file with signature verification

--- a/client-cli/docs/manual/list-pending.md
+++ b/client-cli/docs/manual/list-pending.md
@@ -1,0 +1,63 @@
+# `client list-pending`
+
+- **Usage**: `client list-pending [OPTIONS] -K <SECRET_KEY>`
+- **Source**: [`src/commands/list_pending.rs`](../../src/commands/list_pending.rs)
+
+List all files on the backend that still need your signature. The command authenticates with your secret key and returns only the files where your public key is among the expected signers.
+
+## Options
+
+### `-K --secret-key <PATH>`
+
+Path to your secret key file. Required.
+
+### `-p --password <PASSWORD>`
+
+Password for the secret key. Conflicts with `--password-file`. Prompted interactively if neither is set.
+
+### `-P --password-file <PATH>`
+
+File containing the password. Conflicts with `--password`.
+
+### `-u --backend-url <URL>`
+
+Backend API URL. Defaults to `http://127.0.0.1:3000`.
+
+### `--json`
+
+Emit the backend response as JSON instead of human-readable text.
+
+## Environment
+
+- `ASFALOAD_LIST_PENDING_PASSWORD` — alternative to `--password`.
+- `ASFALOAD_LIST_PENDING_PASSWORD_FILE` — alternative to `--password-file`.
+
+## Output
+
+Human-readable (default), when files are pending:
+
+    Files requiring your signature:
+      - https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json
+      - https/github.com/443/acme/repo/releases/tag/v2.0/asfaload.index.json
+
+When nothing is pending:
+
+    No pending signatures found.
+
+JSON (with `--json`):
+
+    {"file_paths":["https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json"]}
+
+## Examples
+
+    # list pending files
+    client list-pending -K ~/.asfaload/key.minisign
+
+    # non-interactive, piped into sign-pending
+    client list-pending --json -K ~/.asfaload/key.minisign -p "$PASSWORD" \
+        | jq -r '.file_paths[]'
+
+## Exit codes
+
+- `0` — query succeeded (even if no files are pending).
+- non-zero — error (authentication failure, network error).

--- a/client-cli/docs/manual/new-keys.md
+++ b/client-cli/docs/manual/new-keys.md
@@ -1,0 +1,73 @@
+# `client new-keys`
+
+- **Usage**: `client new-keys [OPTIONS] -n <NAME> -o <OUTPUT_DIR>`
+- **Source**: [`src/commands/keys.rs`](../../src/commands/keys.rs)
+
+Generate a new signing key pair. The command creates both a secret key and a public key in the specified directory.
+
+## Options
+
+### `-n --name <NAME>`
+
+Base name for the key files. Produces `<NAME>` (secret key) and `<NAME>.pub` (public key) in the output directory.
+
+### `-o --output-dir <DIR>`
+
+Directory to write the key files into. Created automatically if it doesn't exist.
+
+### `-a --algorithm <ALGORITHM>`
+
+Signing algorithm to use. Defaults to `minisign`.
+
+| Value | Description |
+|-------|-------------|
+| `minisign` | Minisign format (default) |
+| `ed25519` | Raw Ed25519 |
+
+### `-p --password <PASSWORD>`
+
+Password to protect the secret key. Conflicts with `--password-file`. Prompted interactively if neither is set.
+
+### `-P --password-file <PATH>`
+
+File containing the password. Conflicts with `--password`.
+
+### `--accept-weak-password`
+
+Bypass password strength validation. **Insecure** — only use for testing.
+
+### `--json`
+
+Emit output as JSON instead of human-readable text.
+
+## Environment
+
+- `ASFALOAD_NEW_KEYS_PASSWORD` — alternative to `--password`.
+- `ASFALOAD_NEW_KEYS_PASSWORD_FILE` — alternative to `--password-file`.
+
+## Output
+
+Human-readable (default):
+
+    Generating Minisign keypair with name 'mykey' in directory "/home/user/.asfaload"
+    Public key saved at /home/user/.asfaload/mykey.pub and secret key at /home/user/.asfaload/mykey
+
+JSON (with `--json`):
+
+    {"public_key_path":"/home/user/.asfaload/mykey.pub","secret_key_path":"/home/user/.asfaload/mykey"}
+
+## Examples
+
+    # generate a minisign key pair
+    client new-keys -n mykey -o ~/.asfaload
+
+    # generate an ed25519 key pair
+    client new-keys -n mykey -o ~/.asfaload -a ed25519
+
+    # non-interactive usage in CI
+    client new-keys -n ci-key -o ./keys -p "$KEY_PASSWORD"
+
+## Exit codes
+
+- `0` — key pair created successfully.
+- non-zero — error (invalid directory, password mismatch, etc.).

--- a/client-cli/docs/manual/new-signers-file.md
+++ b/client-cli/docs/manual/new-signers-file.md
@@ -1,0 +1,121 @@
+# `client new-signers-file`
+
+- **Usage**: `client new-signers-file [OPTIONS] -o <OUTPUT_FILE>`
+- **Source**: [`src/commands/signers_file.rs`](../../src/commands/signers_file.rs)
+
+Create a new signers file that defines who can sign artifacts, administer, and manage the project. At minimum, one artifact signer and its threshold are required.
+
+## Options
+
+### Artifact signers
+
+Every signers file needs at least one artifact signer.
+
+#### `-a --artifact-signer <BASE64_KEY>`
+
+Public key as a base64 string. Repeatable.
+
+#### `--artifact-signer-file <PATH>`
+
+Path to a `.pub` key file. Repeatable. Combines with `--artifact-signer`.
+
+#### `-A --artifact-threshold <N>`
+
+Number of artifact signers required to complete a signature. Must be between 1 and the total number of artifact signers.
+
+### Admin keys (optional)
+
+#### `-d --admin-key <BASE64_KEY>`
+
+Admin public key as a base64 string. Repeatable.
+
+#### `--admin-key-file <PATH>`
+
+Path to an admin `.pub` key file. Repeatable.
+
+#### `-D --admin-threshold <N>`
+
+Required when admin keys are provided. Number of admins required to approve changes.
+
+### Master keys (optional)
+
+#### `-m --master-key <BASE64_KEY>`
+
+Master public key as a base64 string. Repeatable.
+
+#### `--master-key-file <PATH>`
+
+Path to a master `.pub` key file. Repeatable.
+
+#### `-M --master-threshold <N>`
+
+Required when master keys are provided.
+
+### Revocation keys (optional)
+
+#### `-r --revocation-key <BASE64_KEY>`
+
+Revocation public key as a base64 string. Repeatable.
+
+#### `--revocation-key-file <PATH>`
+
+Path to a revocation `.pub` key file. Repeatable.
+
+#### `-R --revocation-threshold <N>`
+
+Required when revocation keys are provided.
+
+### General
+
+#### `-o --output-file <PATH>`
+
+Path for the new signers file. The file must not already exist — the command refuses to overwrite. Parent directories are created automatically.
+
+#### `--json`
+
+Emit output as JSON instead of human-readable text.
+
+## Output
+
+Human-readable (default):
+
+    Signers file created successfully at: "signers.json"
+    Artifact signers: 3 (threshold: 2)
+    Admin keys: 1 (threshold: 1)
+    Master keys: 0 (threshold: none)
+
+JSON (with `--json`):
+
+    {"output_file":"signers.json","artifact_signers_count":3,"artifact_threshold":2,"admin_keys_count":1,"admin_threshold":1,"master_keys_count":0,"master_threshold":null,"revocation_keys_count":0,"revocation_threshold":null}
+
+## Examples
+
+    # minimal: two artifact signers, threshold of 2
+    client new-signers-file \
+        --artifact-signer-file alice.pub \
+        --artifact-signer-file bob.pub \
+        -A 2 \
+        -o signers.json
+
+    # with admin and revocation groups
+    client new-signers-file \
+        --artifact-signer-file alice.pub \
+        --artifact-signer-file bob.pub \
+        -A 2 \
+        --admin-key-file admin.pub \
+        -D 1 \
+        --revocation-key-file revoke.pub \
+        -R 1 \
+        -o signers.json
+
+    # mix base64 strings and files
+    client new-signers-file \
+        -a "minisign:RWQwtmTQyX/sEi37..." \
+        --artifact-signer-file bob.pub \
+        -A 1 \
+        -o signers.json
+
+## Exit codes
+
+- `0` — signers file created.
+- non-zero — error (output file exists, invalid threshold, missing keys, etc.).

--- a/client-cli/docs/manual/new-signers-file.md
+++ b/client-cli/docs/manual/new-signers-file.md
@@ -83,6 +83,7 @@ Human-readable (default):
     Artifact signers: 3 (threshold: 2)
     Admin keys: 1 (threshold: 1)
     Master keys: 0 (threshold: none)
+    Revocation keys: 0 (threshold: none)
 
 JSON (with `--json`):
 

--- a/client-cli/docs/manual/register-assets.md
+++ b/client-cli/docs/manual/register-assets.md
@@ -1,0 +1,70 @@
+# `client register-assets`
+
+- **Usage**: `client register-assets [OPTIONS] -K <SECRET_KEY>`
+- **Source**: [`src/commands/register_assets.rs`](../../src/commands/register_assets.rs)
+
+Register assets for signing. Tell the backend about a new set of files — either a GitHub release or one or more checksum files — so that the signature collection process can begin.
+
+After registration you still need to sign the assets yourself with [`sign-pending`](sign-pending.md).
+
+## Options
+
+### `--github-release-url <URL>`
+
+URL of a GitHub release page. The backend fetches the release assets automatically. Mutually exclusive with `--csum-file`.
+
+### `--csum-file <URL>`
+
+URL of a checksums file. Repeatable — pass once per file. All URLs must share a common parent path. Mutually exclusive with `--github-release-url`.
+
+### `-K --secret-key <PATH>`
+
+Path to your secret key file. Required.
+
+### `-p --password <PASSWORD>`
+
+Password for the secret key. Conflicts with `--password-file`. Prompted interactively if neither is set.
+
+### `-P --password-file <PATH>`
+
+File containing the password. Conflicts with `--password`.
+
+### `-u --backend-url <URL>`
+
+Backend API URL. Defaults to `http://127.0.0.1:3000`.
+
+### `--json`
+
+Emit output as JSON instead of human-readable text.
+
+## Environment
+
+- `ASFALOAD_REGISTER_ASSETS_PASSWORD` — alternative to `--password`.
+- `ASFALOAD_REGISTER_ASSETS_PASSWORD_FILE` — alternative to `--password-file`.
+
+## Output
+
+Human-readable (default):
+
+    Assets registered successfully! Remember you still need to sign it yourself!
+    Index file path: https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json
+
+JSON (with `--json`):
+
+    {"success":true,"message":"","index_file_path":"https/github.com/443/acme/tool/releases/tag/v1.0/asfaload.index.json"}
+
+## Examples
+
+    # register a GitHub release
+    client register-assets -K ~/.asfaload/key.minisign \
+        --github-release-url https://github.com/acme/tool/releases/tag/v1.0
+
+    # register checksum files
+    client register-assets -K ~/.asfaload/key.minisign \
+        --csum-file https://example.com/releases/v1.0/SHA256SUMS \
+        --csum-file https://example.com/releases/v1.0/SHA512SUMS
+
+## Exit codes
+
+- `0` — assets registered.
+- non-zero — error (authentication failure, invalid URL, mutually exclusive flags, network error).

--- a/client-cli/docs/manual/register-repo.md
+++ b/client-cli/docs/manual/register-repo.md
@@ -1,0 +1,72 @@
+# `client register-repo`
+
+- **Usage**: `client register-repo [OPTIONS] -K <SECRET_KEY> <SIGNERS_FILE_URL>`
+- **Source**: [`src/commands/register_repo.rs`](../../src/commands/register_repo.rs)
+
+Register a new repository with the backend. Points the backend at your signers file so it knows which keys are authorized to sign artifacts for this project.
+
+After registration, all signers listed in the file must submit their signatures to activate the project.
+
+## Arguments
+
+### `<SIGNERS_FILE_URL>`
+
+Public URL to the signers file on the forge. For example:
+
+    https://raw.githubusercontent.com/owner/repo/main/asfaload.signers/index.json
+
+## Options
+
+### `-K --secret-key <PATH>`
+
+Path to your secret key file. Required.
+
+### `-p --password <PASSWORD>`
+
+Password for the secret key. Conflicts with `--password-file`. Prompted interactively if neither is set.
+
+### `-P --password-file <PATH>`
+
+File containing the password. Conflicts with `--password`.
+
+### `-u --backend-url <URL>`
+
+Backend API URL. Defaults to `http://127.0.0.1:3000`.
+
+### `--json`
+
+Emit output as JSON instead of human-readable text.
+
+## Environment
+
+- `ASFALOAD_REGISTER_REPO_PASSWORD` — alternative to `--password`.
+- `ASFALOAD_REGISTER_REPO_PASSWORD_FILE` — alternative to `--password-file`.
+
+## Output
+
+Human-readable (default):
+
+    Repository registered successfully!
+    Project ID: abc123
+    Required signers (2): alice, bob
+    Next step: signers must submit signatures to activate the project.
+
+JSON (with `--json`):
+
+    {"success":true,"project_id":"abc123","required_signers":["alice","bob"],"message":""}
+
+## Examples
+
+    # register a GitHub-hosted signers file
+    client register-repo -K ~/.asfaload/key.minisign \
+        https://raw.githubusercontent.com/acme/tool/main/asfaload.signers/index.json
+
+    # with explicit backend
+    client register-repo -K ~/.asfaload/key.minisign \
+        -u https://asfaload.example.com \
+        https://raw.githubusercontent.com/acme/tool/main/asfaload.signers/index.json
+
+## Exit codes
+
+- `0` — repository registered.
+- non-zero — error (authentication failure, invalid signers file URL, network error).

--- a/client-cli/docs/manual/revoke.md
+++ b/client-cli/docs/manual/revoke.md
@@ -1,0 +1,62 @@
+# `client revoke`
+
+- **Usage**: `client revoke [OPTIONS] -K <SECRET_KEY> <FILE_PATH>`
+- **Source**: [`src/commands/revoke.rs`](../../src/commands/revoke.rs)
+
+Revoke a previously signed file on the mirror. The command fetches the file from the backend, builds a revocation document (timestamped, with the initiator's public key and the file's SHA-512 digest), signs it, and submits it.
+
+Once revoked, clients that [`download`](download.md) the file will see a revocation warning.
+
+## Arguments
+
+### `<FILE_PATH>`
+
+Mirror-relative path to the signed file, for example `https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json`.
+
+## Options
+
+### `-K --secret-key <PATH>`
+
+Path to your secret key file. Required.
+
+### `-p --password <PASSWORD>`
+
+Password for the secret key. Conflicts with `--password-file`. Prompted interactively if neither is set.
+
+### `-P --password-file <PATH>`
+
+File containing the password. Conflicts with `--password`.
+
+### `-u --backend-url <URL>`
+
+Backend API URL. Defaults to `http://127.0.0.1:3000`.
+
+### `--json`
+
+Emit output as JSON instead of human-readable text.
+
+## Environment
+
+- `ASFALOAD_REVOKE_PASSWORD` — alternative to `--password`.
+- `ASFALOAD_REVOKE_PASSWORD_FILE` — alternative to `--password-file`.
+
+## Output
+
+Human-readable (default):
+
+    Success! File revoked: https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json
+
+JSON (with `--json`):
+
+    {"success":true,"message":""}
+
+## Examples
+
+    # revoke a release index
+    client revoke -K ~/.asfaload/key.minisign \
+        https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json
+
+## Exit codes
+
+- `0` — file revoked.
+- non-zero — error (authentication failure, file not found, not authorized, network error).

--- a/client-cli/docs/manual/sign-pending.md
+++ b/client-cli/docs/manual/sign-pending.md
@@ -1,0 +1,70 @@
+# `client sign-pending`
+
+- **Usage**: `client sign-pending [OPTIONS] -K <SECRET_KEY> <FILE_PATH>`
+- **Source**: [`src/commands/sign_pending.rs`](../../src/commands/sign_pending.rs)
+
+Sign a pending file. The command fetches all files associated with the given path from the backend, computes a SHA-512 hash of each, signs them with your secret key, and submits the signatures in a single request.
+
+Use [`list-pending`](list-pending.md) to discover which files need signing.
+
+## Arguments
+
+### `<FILE_PATH>`
+
+Mirror-relative path to the file to sign, as returned by `list-pending`. For example `https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json`.
+
+## Options
+
+### `-K --secret-key <PATH>`
+
+Path to your secret key file. Required.
+
+### `-p --password <PASSWORD>`
+
+Password for the secret key. Conflicts with `--password-file`. Prompted interactively if neither is set.
+
+### `-P --password-file <PATH>`
+
+File containing the password. Conflicts with `--password`.
+
+### `-u --backend-url <URL>`
+
+Backend API URL. Defaults to `http://127.0.0.1:3000`.
+
+### `--json`
+
+Emit output as JSON instead of human-readable text.
+
+## Environment
+
+- `ASFALOAD_SIGN_PENDING_PASSWORD` — alternative to `--password`.
+- `ASFALOAD_SIGN_PENDING_PASSWORD_FILE` — alternative to `--password-file`.
+
+## Output
+
+Human-readable (default):
+
+    Success! Signature submitted
+
+When the submission completes the required threshold:
+
+    Success! Signature submitted (complete)
+
+JSON (with `--json`):
+
+    {"is_complete":true}
+
+## Examples
+
+    # sign a pending release index
+    client sign-pending -K ~/.asfaload/key.minisign \
+        https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json
+
+    # sign with explicit password (CI usage)
+    client sign-pending -K ~/.asfaload/key.minisign -p "$PASSWORD" \
+        https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json
+
+## Exit codes
+
+- `0` — signature submitted successfully.
+- non-zero — error (authentication failure, file not found, network error).

--- a/client-cli/docs/manual/update-signers.md
+++ b/client-cli/docs/manual/update-signers.md
@@ -1,0 +1,65 @@
+# `client update-signers`
+
+- **Usage**: `client update-signers [OPTIONS] -K <SECRET_KEY> <SIGNERS_FILE_URL>`
+- **Source**: [`src/commands/update_signers.rs`](../../src/commands/update_signers.rs)
+
+Propose an update to an existing project's signers file. The backend fetches the new file from the forge and starts a signature collection round — signers from the **current** configuration must approve the change before it takes effect.
+
+## Arguments
+
+### `<SIGNERS_FILE_URL>`
+
+Public URL to the **new** signers file on the forge. For example:
+
+    https://raw.githubusercontent.com/owner/repo/main/asfaload.signers/index.json
+
+## Options
+
+### `-K --secret-key <PATH>`
+
+Path to your secret key file. Required.
+
+### `-p --password <PASSWORD>`
+
+Password for the secret key. Conflicts with `--password-file`. Prompted interactively if neither is set.
+
+### `-P --password-file <PATH>`
+
+File containing the password. Conflicts with `--password`.
+
+### `-u --backend-url <URL>`
+
+Backend API URL. Defaults to `http://127.0.0.1:3000`.
+
+### `--json`
+
+Emit output as JSON instead of human-readable text.
+
+## Environment
+
+- `ASFALOAD_UPDATE_SIGNERS_PASSWORD` — alternative to `--password`.
+- `ASFALOAD_UPDATE_SIGNERS_PASSWORD_FILE` — alternative to `--password-file`.
+
+## Output
+
+Human-readable (default):
+
+    Signers update proposed successfully!
+    Project ID: abc123
+    Required signers (2): alice, bob
+    Next step: signers must submit signatures to activate the update.
+
+JSON (with `--json`):
+
+    {"success":true,"project_id":"abc123","required_signers":["alice","bob"],"message":""}
+
+## Examples
+
+    # propose a signers update
+    client update-signers -K ~/.asfaload/key.minisign \
+        https://raw.githubusercontent.com/acme/tool/main/asfaload.signers/index.json
+
+## Exit codes
+
+- `0` — update proposed.
+- non-zero — error (authentication failure, invalid signers file, network error).

--- a/client-cli/src/commands/signers_file.rs
+++ b/client-cli/src/commands/signers_file.rs
@@ -162,6 +162,11 @@ pub fn handle_new_signers_file_command(
             all_master_keys_count,
             master_threshold.map_or("none".to_string(), |t| t.to_string())
         );
+        println!(
+            "Revocation keys: {} (threshold: {})",
+            all_revocation_keys_count,
+            revocation_threshold.map_or("none".to_string(), |t| t.to_string())
+        );
     }
 
     Ok(())

--- a/client-cli/tests/json_output_test.rs
+++ b/client-cli/tests/json_output_test.rs
@@ -103,6 +103,37 @@ fn test_new_signers_file_json_output() {
     assert!(!json["output_file"].as_str().unwrap().is_empty());
 }
 
+#[test]
+fn test_new_signers_file_human_output_includes_revocation_keys() {
+    let (_key_dir, key_path) = generate_test_keypair();
+    let temp_dir = TempDir::new().unwrap();
+    let output_file = temp_dir.path().join("signers.json");
+
+    let pub_key_path = format!("{}.pub", key_path.to_string_lossy());
+
+    let mut cmd = assert_cmd::cargo_bin_cmd!("client-cli");
+    cmd.arg("new-signers-file")
+        .arg("--artifact-signer-file")
+        .arg(&pub_key_path)
+        .arg("-A")
+        .arg("1")
+        .arg("--revocation-key-file")
+        .arg(&pub_key_path)
+        .arg("-R")
+        .arg("1")
+        .arg("-o")
+        .arg(&output_file);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Artifact signers: 1 (threshold: 1)",
+        ))
+        .stdout(predicate::str::contains(
+            "Revocation keys: 1 (threshold: 1)",
+        ));
+}
+
 // -------------------------------------------------------------------
 // Error as JSON
 // -------------------------------------------------------------------


### PR DESCRIPTION
Document the 9 remaining client-cli commands (new-keys, new-signers-file, list-pending, sign-pending, register-repo, register-assets, update-signers, revoke, download) and update the index to link all commands by category.