### PR TITLE
docs(rest-api): add reference docs for all REST API endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,9 @@ Never open or consider any file specified in ./.agentsignore. The .agentsignore 
 ## Build/Test/Lint Commands
 
 ### Core Commands
-- `cargo test` - Run all tests across workspace
+- `make test` - Run all tests across workspace, also test-utils feature-gated tests. Do not attempt to run all test with `cargo test`.
 - `cargo test <test_name>` - Run a specific test by name
+- `cargo test --features test-util <test_name>` - Run a specific rest-utils feature-gated test by name
 - `cargo test --package <crate_name>` - Run tests for a specific crate
 - `cargo test --package <crate_name> <test_name>` - Run specific test in specific crate
 - `cargo check` - Check code for errors without building

--- a/rest-api/docs/manual/files-to-sign.md
+++ b/rest-api/docs/manual/files-to-sign.md
@@ -1,0 +1,73 @@
+# `GET /v1/files-to-sign/{file_path}`
+
+- **Auth**: required
+- **Source**: [`src/handlers.rs`](../../src/handlers.rs) — `get_files_to_sign_handler`
+
+Fetch the contents of all files that need to be signed for a given artifact. For regular files, the response contains only the primary file. For signers files, it includes both the signers file and its metadata file. All contents are base64-encoded.
+
+This endpoint is used by the client CLI during the sign-pending workflow to retrieve file contents before computing signatures locally.
+
+## Path parameters
+
+### `file_path`
+
+Mirror-relative path to the file. Slashes are preserved (the route uses a catch-all parameter).
+
+## Request headers
+
+Standard Asfaload authentication headers, signed by the caller's secret key:
+
+- `X-asfld-timestamp` — Unix timestamp, seconds.
+- `X-asfld-nonce` — random nonce.
+- `X-asfld-sig` — Ed25519 signature over the canonical request string.
+- `X-asfld-pk` — caller's public key.
+
+## Response
+
+### `200 OK`
+
+For a regular artifact:
+
+    {
+      "files": {
+        "https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json": "<base64-content>"
+      }
+    }
+
+For a signers file (includes metadata):
+
+    {
+      "files": {
+        "https/github.com/443/acme/repo/asfaload.signers.pending/asfaload.signers.json": "<base64-content>",
+        "https/github.com/443/acme/repo/asfaload.signers.pending/asfaload.signers.json.metadata.json": "<base64-content>"
+      }
+    }
+
+Fields:
+
+- `files` — map of mirror-relative file paths to their base64-encoded contents.
+
+## Errors
+
+- `400 Bad Request` — invalid file path.
+- `401 Unauthorized` — missing or invalid authentication headers.
+- `404 Not Found` — file does not exist.
+- `500 Internal Server Error` — failed to determine file type, read file, or locate metadata file for a signers file.
+
+## Examples
+
+### Fetch files for a release artifact
+
+    curl -sS 'http://127.0.0.1:3000/v1/files-to-sign/https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json' \
+      -H 'X-asfld-timestamp: 1712860800' \
+      -H 'X-asfld-nonce: <random-nonce>' \
+      -H 'X-asfld-sig: <base64-signature>' \
+      -H 'X-asfld-pk: <base64-public-key>'
+
+    {"files":{"https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json":"<base64-content>"}}
+
+### File not found
+
+    HTTP/1.1 404 Not Found
+
+    {"error":"File not found: https/github.com/443/acme/repo/releases/tag/v1.0/missing.json"}

--- a/rest-api/docs/manual/get-file.md
+++ b/rest-api/docs/manual/get-file.md
@@ -1,0 +1,44 @@
+# `GET /v1/files/{file_path}`
+
+- **Auth**: none
+- **Source**: [`src/handlers.rs`](../../src/handlers.rs) — `get_file_handler`
+
+Fetch the raw content of a file from the repository. Returns the file as an `application/octet-stream` byte stream. This is a public endpoint — no authentication is required.
+
+The server validates the path against directory traversal attempts before reading.
+
+## Path parameters
+
+### `file_path`
+
+Mirror-relative path to the file. Slashes are preserved (the route uses a catch-all parameter).
+
+## Response
+
+### `200 OK`
+
+Raw file bytes with headers:
+
+- `Content-Type: application/octet-stream`
+- `Content-Length: <size-in-bytes>`
+
+## Errors
+
+- `400 Bad Request` — invalid file path or path traversal detected, or path points to a directory.
+- `404 Not Found` — file does not exist.
+- `500 Internal Server Error` — failed to read the file.
+
+## Examples
+
+### Fetch a file
+
+    curl -sS 'http://127.0.0.1:3000/v1/files/https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json' \
+      -o index.json
+
+### File not found
+
+    curl -sS -i 'http://127.0.0.1:3000/v1/files/https/github.com/443/acme/repo/releases/tag/v1.0/missing.json'
+
+    HTTP/1.1 404 Not Found
+
+    {"error":"File not found: https/github.com/443/acme/repo/releases/tag/v1.0/missing.json"}

--- a/rest-api/docs/manual/get-signers-chain.md
+++ b/rest-api/docs/manual/get-signers-chain.md
@@ -1,0 +1,57 @@
+# `GET /v1/get_signers_chain/{artifact_path}`
+
+- **Auth**: none
+- **Source**: [`src/handlers.rs`](../../src/handlers.rs) — `get_signers_chain_handler`
+
+Fetch the signers history chain for a signed artifact. The server traces the artifact's local signers copy back to its source commit, reads the history file and all associated signers/metadata/signature files at that point in time, and returns the chain of signers configurations that were active up to and including the one used to sign the artifact.
+
+This endpoint is useful for verifying the full provenance of an artifact's signing authority.
+
+## Path parameters
+
+### `artifact_path`
+
+Mirror-relative path to the signed artifact. Slashes are preserved (the route uses a catch-all parameter).
+
+## Response
+
+### `200 OK`
+
+    {
+      "history": {
+        "entries": [
+          {
+            "signers_config": "...",
+            "signatures": "...",
+            "metadata": "...",
+            "metadata_signatures": "...",
+            "timestamp": "2024-04-11T12:00:00Z"
+          }
+        ]
+      }
+    }
+
+Fields:
+
+- `history` — a `HistoryFile` object containing the chain of signers configurations. Each entry includes the signers config, its signatures, metadata, metadata signatures, and the timestamp when it became active. The chain is filtered to entries relevant to the artifact's signing time.
+
+## Errors
+
+- `400 Bad Request` — invalid artifact path or cannot derive signers path.
+- `500 Internal Server Error` — failed to trace signers source, read files from Git history, or build the chain.
+
+## Examples
+
+### Fetch the signers chain
+
+    curl -sS 'http://127.0.0.1:3000/v1/get_signers_chain/https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json'
+
+    {"history":{"entries":[...]}}
+
+### Invalid artifact path
+
+    curl -sS -i 'http://127.0.0.1:3000/v1/get_signers_chain/invalid'
+
+    HTTP/1.1 400 Bad Request
+
+    {"error":"Invalid artifact path: ..."}

--- a/rest-api/docs/manual/get-signers.md
+++ b/rest-api/docs/manual/get-signers.md
@@ -1,0 +1,45 @@
+# `GET /v1/get_signers/{file_path}`
+
+- **Auth**: none
+- **Source**: [`src/handlers.rs`](../../src/handlers.rs) — `get_signers_handler`
+
+Fetch the signers configuration that applies to a given path. The server walks parent directories from the given path upward until it finds an active signers file, then returns its raw JSON content. This is a public endpoint — no authentication is required.
+
+## Path parameters
+
+### `file_path`
+
+Mirror-relative path to any file or directory in the repository. The server locates the nearest signers file by traversing parent directories. Slashes are preserved (the route uses a catch-all parameter).
+
+## Response
+
+### `200 OK`
+
+Raw signers file JSON with headers:
+
+- `Content-Type: application/json`
+- `Content-Length: <size-in-bytes>`
+
+The body is the signers configuration file as stored on disk — a `SignersConfig` JSON object.
+
+## Errors
+
+- `400 Bad Request` — invalid file path.
+- `404 Not Found` — no signers file found in any parent directory of the given path.
+- `500 Internal Server Error` — failed to read the signers file.
+
+## Examples
+
+### Fetch signers for a release artifact
+
+    curl -sS 'http://127.0.0.1:3000/v1/get_signers/https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json'
+
+Returns the content of the nearest `asfaload.signers/asfaload.signers.json` ancestor.
+
+### No signers file found
+
+    curl -sS -i 'http://127.0.0.1:3000/v1/get_signers/https/github.com/443/unknown/repo/file.txt'
+
+    HTTP/1.1 404 Not Found
+
+    {"error":"No signers file found for: https/github.com/443/unknown/repo/file.txt. Error: No signers file found in parent directories"}

--- a/rest-api/docs/manual/index.md
+++ b/rest-api/docs/manual/index.md
@@ -2,6 +2,31 @@
 
 Reference for the Asfaload REST API.
 
+## Registration
+
+- [`POST /v1/register_repo`](register-repo.md) — register a new project with the signing server
+- [`POST /v1/update_signers`](update-signers.md) — propose an update to a project's signers file
+
 ## Signatures
 
+- [`POST /v1/signatures`](submit-signature.md) — submit signatures for a file
 - [`GET /v1/signatures/{file_path}`](signature-status.md) — query signature collection status for a file
+- [`GET /v1/pending_signatures`](pending-signatures.md) — list files awaiting the caller's signature
+
+## Files
+
+- [`GET /v1/files/{file_path}`](get-file.md) — fetch raw file content from the repository
+- [`GET /v1/files-to-sign/{file_path}`](files-to-sign.md) — fetch file contents needed for signing
+
+## Signers
+
+- [`GET /v1/get_signers/{file_path}`](get-signers.md) — get the signers configuration for a path
+- [`GET /v1/get_signers_chain/{artifact_path}`](get-signers-chain.md) — get the signers history chain for a signed artifact
+
+## Revocation
+
+- [`POST /v1/revoke`](revoke.md) — revoke a previously signed file
+
+## Assets
+
+- [`POST /v1/assets`](register-assets.md) — register assets from a GitHub release or checksums files

--- a/rest-api/docs/manual/pending-signatures.md
+++ b/rest-api/docs/manual/pending-signatures.md
@@ -1,0 +1,53 @@
+# `GET /v1/pending_signatures`
+
+- **Auth**: required
+- **Source**: [`src/handlers.rs`](../../src/handlers.rs) — `get_pending_signatures_handler`
+
+List all files that still need the caller's signature. The server walks the repository, finds files with pending aggregate signatures, and filters to those where the caller is an authorized signer who has not yet signed.
+
+The returned paths point to the artifact files themselves, not to the `.signatures.json.pending` files used internally.
+
+## Request headers
+
+Standard Asfaload authentication headers, signed by the caller's secret key:
+
+- `X-asfld-timestamp` — Unix timestamp, seconds.
+- `X-asfld-nonce` — random nonce.
+- `X-asfld-sig` — Ed25519 signature over the canonical request string.
+- `X-asfld-pk` — caller's public key.
+
+## Response
+
+### `200 OK`
+
+    {
+      "file_paths": [
+        "https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json",
+        "https/github.com/443/acme/repo/asfaload.signers.pending/asfaload.signers.json"
+      ]
+    }
+
+Fields:
+
+- `file_paths` — list of mirror-relative paths to files awaiting the caller's signature. Empty array if nothing is pending.
+
+## Errors
+
+- `401 Unauthorized` — missing or invalid authentication headers.
+- `500 Internal Server Error` — failed to scan repository or check signer authorization.
+
+## Examples
+
+### Files pending signature
+
+    curl -sS 'http://127.0.0.1:3000/v1/pending_signatures' \
+      -H 'X-asfld-timestamp: 1712860800' \
+      -H 'X-asfld-nonce: <random-nonce>' \
+      -H 'X-asfld-sig: <base64-signature>' \
+      -H 'X-asfld-pk: <base64-public-key>'
+
+    {"file_paths":["https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json"]}
+
+### Nothing pending
+
+    {"file_paths":[]}

--- a/rest-api/docs/manual/register-assets.md
+++ b/rest-api/docs/manual/register-assets.md
@@ -1,0 +1,100 @@
+# `POST /v1/assets`
+
+- **Auth**: required
+- **Source**: [`src/handlers.rs`](../../src/handlers.rs) — `register_assets_handler`
+
+Register assets for signing. Accepts either a GitHub release URL or a list of checksums file URLs — exactly one must be provided.
+
+In GitHub mode, the server fetches the release metadata, downloads all assets, builds an index file, and commits everything to the repository. In checksums mode, it downloads the referenced checksums files, builds the index, and commits.
+
+## Request headers
+
+Standard Asfaload authentication headers, signed by the caller's secret key:
+
+- `X-asfld-timestamp` — Unix timestamp, seconds.
+- `X-asfld-nonce` — random nonce.
+- `X-asfld-sig` — Ed25519 signature over the canonical request string.
+- `X-asfld-pk` — caller's public key.
+
+## Request body
+
+JSON object with exactly one of the two fields set:
+
+### GitHub release mode
+
+    {
+      "github_release_url": "https://github.com/acme/repo/releases/tag/v1.0"
+    }
+
+### Checksums mode
+
+    {
+      "csum_files": [
+        "https://example.com/releases/v1.0/SHA256SUMS",
+        "https://example.com/releases/v1.0/SHA512SUMS"
+      ]
+    }
+
+Fields:
+
+- `github_release_url` — full URL to a GitHub release page. Must point to a known GitHub host. Mutually exclusive with `csum_files`.
+- `csum_files` — list of URLs to checksums files. All URLs must share the same origin and parent directory. Mutually exclusive with `github_release_url`.
+
+## Response
+
+### `200 OK`
+
+    {
+      "success": true,
+      "message": "Release registered successfully",
+      "index_file_path": "https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json"
+    }
+
+Fields:
+
+- `success` — always `true` on success.
+- `message` — human-readable status. Either "Release registered successfully" (GitHub mode) or "Assets registered successfully" (checksums mode).
+- `index_file_path` — mirror-relative path to the generated index file.
+
+## Errors
+
+- `400 Bad Request` — both or neither fields provided, invalid URL format, non-GitHub host for `github_release_url`, or invalid checksums URLs.
+- `401 Unauthorized` — missing or invalid authentication headers.
+- `409 Conflict` — release already registered.
+- `500 Internal Server Error` — release processing, checksums download, or Git commit failed.
+
+## Examples
+
+### Register a GitHub release
+
+    curl -sS -X POST 'http://127.0.0.1:3000/v1/assets' \
+      -H 'Content-Type: application/json' \
+      -H 'X-asfld-timestamp: 1712860800' \
+      -H 'X-asfld-nonce: <random-nonce>' \
+      -H 'X-asfld-sig: <base64-signature>' \
+      -H 'X-asfld-pk: <base64-public-key>' \
+      -d '{
+        "github_release_url": "https://github.com/acme/repo/releases/tag/v1.0"
+      }'
+
+    {"success":true,"message":"Release registered successfully","index_file_path":"https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json"}
+
+### Register checksums files
+
+    curl -sS -X POST 'http://127.0.0.1:3000/v1/assets' \
+      -H 'Content-Type: application/json' \
+      -H 'X-asfld-timestamp: 1712860800' \
+      -H 'X-asfld-nonce: <random-nonce>' \
+      -H 'X-asfld-sig: <base64-signature>' \
+      -H 'X-asfld-pk: <base64-public-key>' \
+      -d '{
+        "csum_files": ["https://example.com/releases/v1.0/SHA256SUMS"]
+      }'
+
+    {"success":true,"message":"Assets registered successfully","index_file_path":"https/example.com/443/releases/v1.0/asfaload.index.json"}
+
+### Mutually exclusive fields
+
+    HTTP/1.1 400 Bad Request
+
+    {"error":"github_release_url and csum_files are mutually exclusive"}

--- a/rest-api/docs/manual/register-repo.md
+++ b/rest-api/docs/manual/register-repo.md
@@ -52,8 +52,9 @@ Fields:
 
 ## Errors
 
-- `400 Bad Request` — invalid or unparseable forge URL, project already registered, or invalid public key.
+- `400 Bad Request` — invalid or unparseable forge URL, or invalid public key.
 - `401 Unauthorized` — missing or invalid authentication headers.
+- `409 Conflict` — project is already registered or registration is in progress.
 - `500 Internal Server Error` — forge validation, signers initialisation, or Git commit failed.
 
 ## Examples
@@ -75,6 +76,6 @@ Fields:
 
 ### Project already registered
 
-    HTTP/1.1 400 Bad Request
+    HTTP/1.1 409 Conflict
 
     {"error":"Project 'https/github.com/443/acme/repo' is already registered or registration is in progress."}

--- a/rest-api/docs/manual/register-repo.md
+++ b/rest-api/docs/manual/register-repo.md
@@ -1,0 +1,80 @@
+# `POST /v1/register_repo`
+
+- **Auth**: required
+- **Source**: [`src/handlers.rs`](../../src/handlers.rs) — `register_repo_handler`
+
+Register a new project with the signing server. The server fetches the signers file from the forge URL, validates it, creates the directory structure, records the first signature, and commits the result to the backing Git repository.
+
+A project can only be registered once. Calling this endpoint again for an already-registered project returns an error.
+
+## Request headers
+
+Standard Asfaload authentication headers, signed by the caller's secret key:
+
+- `X-asfld-timestamp` — Unix timestamp, seconds.
+- `X-asfld-nonce` — random nonce.
+- `X-asfld-sig` — Ed25519 signature over the canonical request string.
+- `X-asfld-pk` — caller's public key.
+
+## Request body
+
+JSON object:
+
+    {
+      "signers_file_url": "https://github.com/acme/repo/blob/main/asfaload.signers.json",
+      "public_key": "<base64-public-key>"
+    }
+
+Fields:
+
+- `signers_file_url` — URL pointing to the signers file on the forge (GitHub, GitLab, or file server).
+- `public_key` — base64-encoded Ed25519 public key of the submitter. Must match one of the keys in the signers file.
+
+## Response
+
+### `200 OK`
+
+    {
+      "success": true,
+      "project_id": "https/github.com/443/acme/repo",
+      "message": "Project registered successfully. Collect signatures to activate.",
+      "required_signers": ["<base64-public-key-1>", "<base64-public-key-2>"],
+      "signature_submission_url": "/v1/signatures"
+    }
+
+Fields:
+
+- `success` — always `true` on success.
+- `project_id` — normalised identifier for the registered project.
+- `message` — human-readable status message.
+- `required_signers` — list of base64-encoded public keys that still need to sign.
+- `signature_submission_url` — path to use for submitting signatures.
+
+## Errors
+
+- `400 Bad Request` — invalid or unparseable forge URL, project already registered, or invalid public key.
+- `401 Unauthorized` — missing or invalid authentication headers.
+- `500 Internal Server Error` — forge validation, signers initialisation, or Git commit failed.
+
+## Examples
+
+### Successful registration
+
+    curl -sS -X POST 'http://127.0.0.1:3000/v1/register_repo' \
+      -H 'Content-Type: application/json' \
+      -H 'X-asfld-timestamp: 1712860800' \
+      -H 'X-asfld-nonce: <random-nonce>' \
+      -H 'X-asfld-sig: <base64-signature>' \
+      -H 'X-asfld-pk: <base64-public-key>' \
+      -d '{
+        "signers_file_url": "https://github.com/acme/repo/blob/main/asfaload.signers.json",
+        "public_key": "<base64-public-key>"
+      }'
+
+    {"success":true,"project_id":"https/github.com/443/acme/repo","message":"Project registered successfully. Collect signatures to activate.","required_signers":["<base64-pk-1>","<base64-pk-2>"],"signature_submission_url":"/v1/signatures"}
+
+### Project already registered
+
+    HTTP/1.1 400 Bad Request
+
+    {"error":"Project 'https/github.com/443/acme/repo' is already registered or registration is in progress."}

--- a/rest-api/docs/manual/revoke.md
+++ b/rest-api/docs/manual/revoke.md
@@ -1,0 +1,82 @@
+# `POST /v1/revoke`
+
+- **Auth**: required
+- **Source**: [`src/handlers.rs`](../../src/handlers.rs) — `revoke_handler`
+
+Revoke a previously signed file. The caller provides a revocation document (as a JSON string), a signature over its SHA-512 digest, and their public key. The server validates that the file has a complete aggregate signature, verifies the revocation authorization, and records the revocation.
+
+Only files with a complete aggregate signature can be revoked. Files that are still collecting signatures or already revoked are rejected.
+
+## Request headers
+
+Standard Asfaload authentication headers, signed by the caller's secret key:
+
+- `X-asfld-timestamp` — Unix timestamp, seconds.
+- `X-asfld-nonce` — random nonce.
+- `X-asfld-sig` — Ed25519 signature over the canonical request string.
+- `X-asfld-pk` — caller's public key.
+
+## Request body
+
+JSON object:
+
+    {
+      "file_path": "https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json",
+      "revocation_json": "{\"reason\":\"compromised\",\"timestamp\":1712860800}",
+      "signature": "<base64-signature>",
+      "public_key": "<base64-public-key>"
+    }
+
+Fields:
+
+- `file_path` — mirror-relative path to the signed file being revoked.
+- `revocation_json` — JSON string of the revocation document (`RevocationInfo`).
+- `signature` — base64-encoded Ed25519 signature of the SHA-512 digest of `revocation_json`.
+- `public_key` — base64-encoded Ed25519 public key of the revoker.
+
+## Response
+
+### `200 OK`
+
+    {
+      "success": true,
+      "message": "File revoked successfully"
+    }
+
+Fields:
+
+- `success` — always `true` on success.
+- `message` — human-readable confirmation.
+
+## Errors
+
+- `400 Bad Request` — empty file path, invalid public key or signature format, digest mismatch, file already revoked, or revocation authorization failed.
+- `401 Unauthorized` — missing or invalid authentication headers.
+- `404 Not Found` — file does not exist.
+- `409 Conflict` — file has not been fully signed yet.
+- `500 Internal Server Error` — revocation processing or Git commit failed.
+
+## Examples
+
+### Successful revocation
+
+    curl -sS -X POST 'http://127.0.0.1:3000/v1/revoke' \
+      -H 'Content-Type: application/json' \
+      -H 'X-asfld-timestamp: 1712860800' \
+      -H 'X-asfld-nonce: <random-nonce>' \
+      -H 'X-asfld-sig: <base64-signature>' \
+      -H 'X-asfld-pk: <base64-public-key>' \
+      -d '{
+        "file_path": "https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json",
+        "revocation_json": "{\"reason\":\"compromised\",\"timestamp\":1712860800}",
+        "signature": "<base64-revocation-signature>",
+        "public_key": "<base64-public-key>"
+      }'
+
+    {"success":true,"message":"File revoked successfully"}
+
+### File not fully signed
+
+    HTTP/1.1 409 Conflict
+
+    {"error":"File has not been fully signed: https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json"}

--- a/rest-api/docs/manual/submit-signature.md
+++ b/rest-api/docs/manual/submit-signature.md
@@ -1,0 +1,79 @@
+# `POST /v1/signatures`
+
+- **Auth**: required
+- **Source**: [`src/handlers.rs`](../../src/handlers.rs) — `submit_signature_handler`
+
+Submit one or more signatures for a file. The server validates each signature against the signer's public key and the file content, adds it to the pending collection, and commits the result to Git. Once all required signatures are collected, the aggregate signature is marked complete.
+
+For signers files, the request must include signatures for both the signers file itself and its metadata file.
+
+## Request headers
+
+Standard Asfaload authentication headers, signed by the caller's secret key:
+
+- `X-asfld-timestamp` — Unix timestamp, seconds.
+- `X-asfld-nonce` — random nonce.
+- `X-asfld-sig` — Ed25519 signature over the canonical request string.
+- `X-asfld-pk` — caller's public key.
+
+## Request body
+
+JSON object:
+
+    {
+      "file_path": "https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json",
+      "public_key": "<base64-public-key>",
+      "signatures": {
+        "https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json": "<base64-signature>"
+      }
+    }
+
+Fields:
+
+- `file_path` — mirror-relative path to the primary file being signed.
+- `public_key` — base64-encoded Ed25519 public key of the signer.
+- `signatures` — map of file paths to their base64-encoded Ed25519 signatures. Must include at least the primary `file_path`. For signers files, include the metadata file path as well.
+
+## Response
+
+### `200 OK`
+
+    {
+      "is_complete": false
+    }
+
+Fields:
+
+- `is_complete` — `true` when all required signatures have been collected; `false` while signatures are still pending.
+
+## Errors
+
+- `400 Bad Request` — empty file path, file not found, invalid public key or signature format, or no signature provided for the primary file.
+- `401 Unauthorized` — missing or invalid authentication headers.
+- `500 Internal Server Error` — signature collection or Git commit failed.
+
+## Examples
+
+### Successful submission (collection not yet complete)
+
+    curl -sS -X POST 'http://127.0.0.1:3000/v1/signatures' \
+      -H 'Content-Type: application/json' \
+      -H 'X-asfld-timestamp: 1712860800' \
+      -H 'X-asfld-nonce: <random-nonce>' \
+      -H 'X-asfld-sig: <base64-signature>' \
+      -H 'X-asfld-pk: <base64-public-key>' \
+      -d '{
+        "file_path": "https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json",
+        "public_key": "<base64-public-key>",
+        "signatures": {
+          "https/github.com/443/acme/repo/releases/tag/v1.0/asfaload.index.json": "<base64-signature>"
+        }
+      }'
+
+    {"is_complete":false}
+
+### File not found
+
+    HTTP/1.1 400 Bad Request
+
+    {"error":"File not found: https/github.com/443/acme/repo/releases/tag/v1.0/missing.json"}

--- a/rest-api/docs/manual/submit-signature.md
+++ b/rest-api/docs/manual/submit-signature.md
@@ -50,6 +50,7 @@ Fields:
 
 - `400 Bad Request` — empty file path, file not found, invalid public key or signature format, or no signature provided for the primary file.
 - `401 Unauthorized` — missing or invalid authentication headers.
+- `409 Conflict` — signature already collected for this key, or signature already added.
 - `500 Internal Server Error` — signature collection or Git commit failed.
 
 ## Examples

--- a/rest-api/docs/manual/update-signers.md
+++ b/rest-api/docs/manual/update-signers.md
@@ -1,0 +1,80 @@
+# `POST /v1/update_signers`
+
+- **Auth**: required
+- **Source**: [`src/handlers.rs`](../../src/handlers.rs) — `update_signers_handler`
+
+Propose an update to a project's signers file. The server fetches the new signers file from the forge, validates it, writes it as a pending proposal, and commits the result. The project must already be registered and have an active signers file.
+
+Like initial registration, the update requires all new signers to submit their signatures before it takes effect.
+
+## Request headers
+
+Standard Asfaload authentication headers, signed by the caller's secret key:
+
+- `X-asfld-timestamp` — Unix timestamp, seconds.
+- `X-asfld-nonce` — random nonce.
+- `X-asfld-sig` — Ed25519 signature over the canonical request string.
+- `X-asfld-pk` — caller's public key.
+
+## Request body
+
+JSON object (same shape as `register_repo`):
+
+    {
+      "signers_file_url": "https://github.com/acme/repo/blob/main/asfaload.signers.json",
+      "public_key": "<base64-public-key>"
+    }
+
+Fields:
+
+- `signers_file_url` — URL pointing to the updated signers file on the forge.
+- `public_key` — base64-encoded Ed25519 public key of the submitter.
+
+## Response
+
+### `200 OK`
+
+    {
+      "success": true,
+      "project_id": "https/github.com/443/acme/repo",
+      "message": "Signers update proposed successfully. Collect signatures to activate.",
+      "required_signers": ["<base64-public-key-1>", "<base64-public-key-2>"],
+      "signature_submission_url": "/v1/signatures"
+    }
+
+Fields:
+
+- `success` — always `true` on success.
+- `project_id` — normalised project identifier.
+- `message` — human-readable status message.
+- `required_signers` — list of base64-encoded public keys that need to sign the update.
+- `signature_submission_url` — path to use for submitting signatures.
+
+## Errors
+
+- `400 Bad Request` — project not registered, no active signers file, invalid forge URL, or invalid public key.
+- `401 Unauthorized` — missing or invalid authentication headers.
+- `500 Internal Server Error` — forge validation, proposal creation, or Git commit failed.
+
+## Examples
+
+### Successful update proposal
+
+    curl -sS -X POST 'http://127.0.0.1:3000/v1/update_signers' \
+      -H 'Content-Type: application/json' \
+      -H 'X-asfld-timestamp: 1712860800' \
+      -H 'X-asfld-nonce: <random-nonce>' \
+      -H 'X-asfld-sig: <base64-signature>' \
+      -H 'X-asfld-pk: <base64-public-key>' \
+      -d '{
+        "signers_file_url": "https://github.com/acme/repo/blob/main/asfaload.signers.json",
+        "public_key": "<base64-public-key>"
+      }'
+
+    {"success":true,"project_id":"https/github.com/443/acme/repo","message":"Signers update proposed successfully. Collect signatures to activate.","required_signers":["<base64-pk-1>","<base64-pk-2>"],"signature_submission_url":"/v1/signatures"}
+
+### Project not registered
+
+    HTTP/1.1 400 Bad Request
+
+    {"error":"Project 'https/github.com/443/acme/repo' is not registered. Register the repo first."}

--- a/rest-api/src/file_auth/actors/signature_collector.rs
+++ b/rest-api/src/file_auth/actors/signature_collector.rs
@@ -467,9 +467,9 @@ impl Message<RevokeFileMessage> for SignatureCollector {
 /// Map an `AggregateSignatureError` to the appropriate `ApiError`.
 fn map_aggregate_signature_error(e: AggregateSignatureError) -> ApiError {
     match e {
-        AggregateSignatureError::DuplicateSignature => {
-            ApiError::InvalidRequestBody("Signature already collected for this key".to_string())
-        }
+        AggregateSignatureError::DuplicateSignature => ApiError::SignatureAlreadyCollected(
+            "Signature already collected for this key".to_string(),
+        ),
         AggregateSignatureError::Signature(msg) => {
             if msg.contains("signature verification failed") {
                 ApiError::SignatureVerificationFailed
@@ -479,7 +479,7 @@ fn map_aggregate_signature_error(e: AggregateSignatureError) -> ApiError {
         }
         AggregateSignatureError::Io(io) => {
             if io.kind() == std::io::ErrorKind::AlreadyExists {
-                ApiError::InvalidRequestBody("Signature already added".to_string())
+                ApiError::SignatureAlreadyCollected("Signature already added".to_string())
             } else {
                 ApiError::InternalServerError(format!("IO error: {}", io))
             }

--- a/rest-api/src/file_auth/actors/signers_initialiser.rs
+++ b/rest-api/src/file_auth/actors/signers_initialiser.rs
@@ -148,7 +148,7 @@ impl Message<InitialiseSignersRequest> for SignersInitialiser {
                 project_id = %project_id,
                 "Project directory structure already exists, indicating a pending or completed registration."
             );
-            return Err(ApiError::InvalidRequestBody(format!(
+            return Err(ApiError::ProjectAlreadyRegistered(format!(
                 "Project '{}' is already registered or registration is in progress.",
                 project_id
             )));
@@ -614,10 +614,10 @@ mod tests {
             Ok(_) => panic!("Expected error for existing directory"),
             Err(send_error) => match send_error {
                 kameo::error::SendError::HandlerError(api_error) => match api_error {
-                    ApiError::InvalidRequestBody(msg) => {
+                    ApiError::ProjectAlreadyRegistered(msg) => {
                         assert!(msg.contains("already registered"));
                     }
-                    _ => panic!("Expected InvalidRequestBody error for existing directory"),
+                    _ => panic!("Expected ProjectAlreadyRegistered error for existing directory"),
                 },
                 _ => panic!("Expected HandlerError for existing directory"),
             },

--- a/rest-api/src/handlers.rs
+++ b/rest-api/src/handlers.rs
@@ -83,7 +83,7 @@ pub async fn register_repo_handler(
             project_id = %project_id,
             "Project directory structure already exists, indicating a pending or completed registration."
         );
-        return Err(ApiError::InvalidRequestBody(format!(
+        return Err(ApiError::ProjectAlreadyRegistered(format!(
             "Project '{}' is already registered or registration is in progress.",
             project_id
         )));

--- a/rest-api/tests/integration_tests.rs
+++ b/rest-api/tests/integration_tests.rs
@@ -920,7 +920,7 @@ pub mod test_utils_tests {
             .send()
             .await?;
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.status(), StatusCode::CONFLICT);
 
         let response_body: serde_json::Value = response.json().await?;
         assert!(response_body.get("error").is_some());

--- a/rest_api_types/src/lib.rs
+++ b/rest_api_types/src/lib.rs
@@ -141,6 +141,12 @@ pub mod errors {
 
         #[error("Release already registered: {0}")]
         ReleaseAlreadyRegistered(String),
+
+        #[error("Project already registered: {0}")]
+        ProjectAlreadyRegistered(String),
+
+        #[error("Signature already collected: {0}")]
+        SignatureAlreadyCollected(String),
     }
 
     #[derive(Error, Debug)]
@@ -239,6 +245,8 @@ pub mod errors {
                 ApiError::FileRevoked(_) => StatusCode::BAD_REQUEST,
                 ApiError::NotAuthorized(_) => StatusCode::FORBIDDEN,
                 ApiError::ReleaseAlreadyRegistered(_) => StatusCode::CONFLICT,
+                ApiError::ProjectAlreadyRegistered(_) => StatusCode::CONFLICT,
+                ApiError::SignatureAlreadyCollected(_) => StatusCode::CONFLICT,
                 ApiError::GitError(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 ApiError::SignersConfigError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             }


### PR DESCRIPTION
Document the 9 previously undocumented endpoints following the same structure as the existing signature-status.md reference page. Each endpoint gets its own file covering auth, request/response shapes, error codes, and curl examples.