### PR TITLE
fix(rest-api): warn on auth failure, not error

### DIFF
--- a/rest-api/src/auth_middleware.rs
+++ b/rest-api/src/auth_middleware.rs
@@ -102,7 +102,7 @@ pub async fn validate_auth(
     let (timestamp, nonce, signature, public_key) = match extracted {
         Ok(values) => values,
         Err(error) => {
-            tracing::error!(
+            tracing::warn!(
                 request_id = %request_id,
                 error = %error,
                 "Failed to extract auth headers"


### PR DESCRIPTION
I had mistakenly merged the PR before I had pushed this change....