### PR TITLE
Chain validation fix

### DIFF
--- a/client-lib/src/signers_chain.rs
+++ b/client-lib/src/signers_chain.rs
@@ -61,10 +61,10 @@ pub(crate) async fn validate_fetched_chain(
     }
 
     // Cryptographic validation of the entire chain (incl. first-entry all-signers).
-    if !features_lib::validate_chain(&chain) {
-        return Err(ClientLibError::SignersChainFirstEntryInvalid(
-            "signers chain validation failed".into(),
-        ));
+    if let Err(e) = features_lib::validate_chain(&chain) {
+        return Err(ClientLibError::SignersChainFirstEntryInvalid(format!(
+            "signers chain validation failed: {e}"
+        )));
     }
 
     // Trust-anchor check: first entry's forge content must match.

--- a/core/common/src/errors.rs
+++ b/core/common/src/errors.rs
@@ -109,6 +109,18 @@ pub enum SignersFileError {
     SignersConfigError(#[from] SignersConfigError),
 }
 
+#[derive(Debug, Error)]
+pub enum SignersChainError {
+    #[error("Current Signers not found")]
+    CurrentNotFound,
+    #[error("Initial signers file validation failed: {0}")]
+    GenesisEntryError(String),
+    #[error("Chain ordering error: {0}")]
+    ChainOrderingError(String),
+    #[error("Signers Chain error: {0}")]
+    GenericError(String),
+}
+
 impl From<SignatureError> for SignersFileError {
     fn from(e: SignatureError) -> Self {
         match e {

--- a/core/features_lib/src/lib.rs
+++ b/core/features_lib/src/lib.rs
@@ -32,7 +32,7 @@ pub use signatures::types::AsfaloadSignatures;
 pub use signers_file::activate_signers_file;
 pub use signers_file::sign_signers_and_metadata_file;
 pub use signers_file::validate_signers_chain_on_disk;
-pub use signers_file::{validate_chain, validate_genesis_entry, validate_history_transitions};
+pub use signers_file::{validate_chain, validate_history_transitions};
 pub use signers_file_types::revocation::RevocationInfo;
 pub use signers_file_types::{
     CurrentSignersInfo, Forge, ForgeOrigin, HistoryEntry, HistoryFile, SignersChain,

--- a/core/signers_file/src/lib.rs
+++ b/core/signers_file/src/lib.rs
@@ -506,36 +506,27 @@ pub fn validate_chain(chain: &SignersChain) -> Result<(), SignersChainError> {
     // otherwise the current entry. The genesis must be fully signed (every key
     // in its config signed both file and metadata).
     match chain.history_entries().first() {
-        Some(h) => {
-            if !validate_full_signatures(
-                &h.signers_file,
-                &h.signatures,
-                &h.metadata,
-                &h.metadata_signatures,
-            ) {
-                Err(SignersChainError::GenesisEntryError(
-                    "Full signatures not validated".into(),
-                ))
-            } else {
-                Ok(())
-            }
-        }
-        None => {
-            if !validate_full_signatures(
-                &current.signers_file,
-                &current.signatures,
-                &current.metadata,
-                &current.metadata_signatures,
-            ) {
-                Err(SignersChainError::GenesisEntryError(
-                    "Genesis entry is current entry, but full signatures not validated".into(),
-                ))
-            } else {
-                Ok(())
-            }
-        }
+        Some(h) => validate_full_signatures(
+            &h.signers_file,
+            &h.signatures,
+            &h.metadata,
+            &h.metadata_signatures,
+        )
+        .then_some(())
+        .ok_or(SignersChainError::GenesisEntryError(
+            "Full signatures not validated".into(),
+        )),
+        None => validate_full_signatures(
+            &current.signers_file,
+            &current.signatures,
+            &current.metadata,
+            &current.metadata_signatures,
+        )
+        .then_some(())
+        .ok_or(SignersChainError::GenesisEntryError(
+            "Genesis entry is current entry, but full signatures not validated".into(),
+        )),
     }?;
-
     validate_history_transitions(chain)
 }
 

--- a/core/signers_file/src/lib.rs
+++ b/core/signers_file/src/lib.rs
@@ -4845,7 +4845,7 @@ mod validate_history_tests {
             current_signers_info: current_from_he(entry2),
         };
 
-        assert!(validate_chain(&chain));
+        assert!(validate_chain(&chain).is_ok());
         Ok(())
     }
 
@@ -4904,7 +4904,7 @@ mod validate_history_tests {
             current_signers_info: current_from_he(entry2),
         };
 
-        assert!(!validate_chain(&chain));
+        assert!(validate_chain(&chain).is_err());
         Ok(())
     }
 
@@ -4934,14 +4934,14 @@ mod validate_history_tests {
             current_signers_info: current_from_he(entry),
         };
 
-        assert!(validate_chain(&chain));
+        assert!(validate_chain(&chain).is_ok());
         Ok(())
     }
 
     #[test]
     fn validate_chain_rejects_empty_chain() {
         let chain = SignersChain::default();
-        assert!(!validate_chain(&chain));
+        assert!(validate_chain(&chain).is_err());
     }
 
     #[test]
@@ -4977,7 +4977,7 @@ mod validate_history_tests {
         };
 
         assert!(
-            !validate_chain(&chain),
+            validate_chain(&chain).is_err(),
             "first entry missing a signersfile signer must fail"
         );
 
@@ -4999,7 +4999,7 @@ mod validate_history_tests {
         };
 
         assert!(
-            !validate_chain(&chain),
+            validate_chain(&chain).is_err(),
             "first entry missing a metadata signer must fail"
         );
         Ok(())
@@ -5071,7 +5071,7 @@ mod validate_history_tests {
             current_signers_info: Some(current),
         };
 
-        assert!(!validate_chain(&chain));
+        assert!(validate_chain(&chain).is_err());
         Ok(())
     }
 
@@ -5161,7 +5161,7 @@ mod validate_history_tests {
         };
 
         assert!(
-            validate_chain(&chain),
+            validate_chain(&chain).is_ok(),
             "validate_chain should accept valid signatures regardless of JSON formatting"
         );
         Ok(())
@@ -5632,9 +5632,12 @@ mod validate_history_tests {
         for sc in first_entry_scenarios() {
             let result = validate_chain(&sc.chain);
             assert_eq!(
-                result, sc.expected_valid,
-                "Scenario '{}': expected valid={}, got valid={}",
-                sc.name, sc.expected_valid, result
+                result.is_ok(),
+                sc.expected_valid,
+                "Scenario '{}': expected valid={}, got valid={} (result: {result:?})",
+                sc.name,
+                sc.expected_valid,
+                result.is_ok(),
             );
         }
     }

--- a/core/signers_file/src/lib.rs
+++ b/core/signers_file/src/lib.rs
@@ -4,7 +4,7 @@ mod validate_history_rotation_tests;
 use aggregate_signature::{AggregateSignature, CompleteSignature, SignatureWithState};
 use common::{
     SignedFileLoader,
-    errors::{AggregateSignatureError, SignersFileError},
+    errors::{AggregateSignatureError, SignersChainError, SignersFileError},
     fs::{
         names::{
             find_global_signers_for, history_file_path_for, metadata_path_for,
@@ -399,21 +399,6 @@ where
     Ok(())
 }
 
-/// Validate the genesis (root) entry of a signers history.
-///
-/// The genesis entry establishes the trust anchor for the chain: every signer
-/// listed in its config must have signed both the `signers_file` bytes and
-/// the `metadata` bytes. This is the cryptographic counterpart to the
-/// trust-anchor forge-content check performed by callers separately.
-pub fn validate_genesis_entry(entry: &CurrentSignersInfo) -> bool {
-    validate_full_signatures(
-        &entry.signers_file,
-        &entry.signatures,
-        &entry.metadata,
-        &entry.metadata_signatures,
-    )
-}
-
 /// Verify that every signer listed in `signers_file`'s parsed config has signed
 /// both the `signers_file` bytes and the `metadata` bytes. This is the
 /// trust-anchor check applied to the genesis entry of a chain — whichever
@@ -444,11 +429,11 @@ fn validate_full_signatures(
 /// For each adjacent pair, verifies that the newer entry's signatures
 /// satisfy `validate_signers_update` against the older entry's config. Also
 /// enforces strict monotonic ordering of `obsoleted_at`. The genesis entry
-/// itself is NOT checked here — see [`validate_genesis_entry`].
+/// itself is NOT checked here, see validate_chain
 ///
 /// An empty or single-entry history is considered valid (vacuously, as there
 /// are no transitions to verify).
-pub fn validate_history_transitions(history: &SignersChain) -> bool {
+pub fn validate_history_transitions(history: &SignersChain) -> Result<(), SignersChainError> {
     // Strict ordering: equal `obsoleted_at` timestamps are rejected. In
     // practice two entries should never share an obsolescence instant, and
     // accepting it would weaken chain auditability. Only history entries
@@ -458,34 +443,40 @@ pub fn validate_history_transitions(history: &SignersChain) -> bool {
         .windows(2)
         .all(|p| p[0].obsoleted_at < p[1].obsoleted_at)
     {
-        return false;
+        return Err(SignersChainError::ChainOrderingError(
+            "entries are not ordered chronologically".into(),
+        ));
     }
 
-    history.entries().windows(2).all(|pair| {
+    history.entries().windows(2).try_for_each(|pair| {
         let parent = &pair[0];
         let updated = &pair[1];
 
-        let parent_signers = match parent.signers_config() {
-            Ok(c) => c,
-            Err(_) => return false,
-        };
-        let updated_signers = match updated.signers_config() {
-            Ok(c) => c,
-            Err(_) => return false,
-        };
+        let parent_signers = parent.signers_config().map_err(|e| {
+            SignersChainError::GenericError(format!(
+                "Problem getting parent signers of transition: {e}"
+            ))
+        })?;
+        let updated_signers = updated.signers_config().map_err(|e| {
+            SignersChainError::GenericError(format!(
+                "Problem getting updated signers of transition: {e}"
+            ))
+        })?;
 
         // Hash the raw JSON bytes (exactly what was originally signed)
-        let file_hash = match common::sha512_for_content(updated.signers_file().as_bytes().to_vec())
-        {
-            Ok(h) => h,
-            Err(_) => return false,
-        };
+        let file_hash = common::sha512_for_content(updated.signers_file().as_bytes().to_vec())
+            .map_err(|e| {
+                SignersChainError::GenericError(format!(
+                    "Problem computing sha512 of signers file content: {e}"
+                ))
+            })?;
 
-        let signatures =
-            match aggregate_signature::parse_tagged_signatures(&updated.signatures().entries) {
-                Ok(s) => s,
-                Err(_) => return false,
-            };
+        let signatures = aggregate_signature::parse_tagged_signatures(
+            &updated.signatures().entries,
+        )
+        .map_err(|e| {
+            SignersChainError::GenericError(format!("Problem parsing tagged signatures: {e}"))
+        })?;
 
         aggregate_signature::validate_signers_update(
             &updated_signers,
@@ -493,6 +484,10 @@ pub fn validate_history_transitions(history: &SignersChain) -> bool {
             &signatures,
             &file_hash,
         )
+        .then_some(())
+        .ok_or(SignersChainError::GenericError(
+            "Signatures criteria for signers update not respected".into(),
+        ))
     })
 }
 
@@ -500,28 +495,46 @@ pub fn validate_history_transitions(history: &SignersChain) -> bool {
 /// transitions. Callers that want "validate the whole chain" should use this.
 ///
 /// An empty chain is considered invalid: a current signers entry is required.
-pub fn validate_chain(chain: &SignersChain) -> bool {
+pub fn validate_chain(chain: &SignersChain) -> Result<(), SignersChainError> {
     let current = match chain.current_signers_info() {
         // No current signers: we need at least a current signers file in the chain
-        None => return false,
+        None => return Err(SignersChainError::CurrentNotFound),
         Some(c) => c,
     };
 
     // Genesis is the oldest entry in the chain — the first history entry if any,
     // otherwise the current entry. The genesis must be fully signed (every key
     // in its config signed both file and metadata).
-    let genesis_ok = match chain.history_entries().first() {
-        Some(h) => validate_full_signatures(
-            &h.signers_file,
-            &h.signatures,
-            &h.metadata,
-            &h.metadata_signatures,
-        ),
-        None => validate_genesis_entry(current),
-    };
-    if !genesis_ok {
-        return false;
-    }
+    match chain.history_entries().first() {
+        Some(h) => {
+            if !validate_full_signatures(
+                &h.signers_file,
+                &h.signatures,
+                &h.metadata,
+                &h.metadata_signatures,
+            ) {
+                Err(SignersChainError::GenesisEntryError(
+                    "Full signatures not validated".into(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+        None => {
+            if !validate_full_signatures(
+                &current.signers_file,
+                &current.signatures,
+                &current.metadata,
+                &current.metadata_signatures,
+            ) {
+                Err(SignersChainError::GenesisEntryError(
+                    "Genesis entry is current entry, but full signatures not validated".into(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+    }?;
 
     validate_history_transitions(chain)
 }
@@ -592,13 +605,9 @@ pub fn validate_signers_chain_on_disk(signers_file_path: &Path) -> Result<(), Si
 
     let entry = CurrentSignersInfo::for_path(signers_file_path)?;
     chain.set_current_info(entry);
-    if validate_chain(&chain) {
-        Ok(())
-    } else {
-        Err(SignersFileError::ChainValidationFailed(
-            "signers chain validation failed".to_string(),
-        ))
-    }
+    validate_chain(&chain).map_err(|e| {
+        SignersFileError::ChainValidationFailed(format!("signers chain validation failed: {e}"))
+    })
 }
 
 #[cfg(test)]

--- a/core/signers_file/src/validate_history_rotation_tests.rs
+++ b/core/signers_file/src/validate_history_rotation_tests.rs
@@ -568,9 +568,12 @@ fn validate_history_rotation_scenarios() {
     for sc in rotation_scenarios() {
         let result = validate_chain(&sc.chain);
         assert_eq!(
-            result, sc.expected_valid,
-            "Scenario '{}': expected valid={}, got valid={}",
-            sc.name, sc.expected_valid, result
+            result.is_ok(),
+            sc.expected_valid,
+            "Scenario '{}': expected valid={}, got valid={} (result: {result:?})",
+            sc.name,
+            sc.expected_valid,
+            result.is_ok(),
         );
     }
 }

--- a/rest_api_types/src/git_backend.rs
+++ b/rest_api_types/src/git_backend.rs
@@ -68,7 +68,9 @@ pub trait GitBackend: Send + Sync + 'static {
         relative_path: &Path,
     ) -> Result<String, ApiError> {
         let spec = format!("{}:{}", commit, relative_path.to_string_lossy());
-        let content = GitCommand::git(self.root(), &["show", &spec]).map_err(|e| {
+        // Verbatim: the returned bytes are hashed to validate signatures, so a
+        // trailing newline must not be stripped (see git_verbatim).
+        let content = GitCommand::git_verbatim(self.root(), &["show", &spec]).map_err(|e| {
             ApiError::GitError(format!(
                 "Failed to read {} at commit {}: {}",
                 relative_path.display(),
@@ -269,9 +271,19 @@ pub struct Sha256GitBackend {
 
 struct GitCommand;
 impl GitCommand {
-    /// Run a git command in the given repo directory. Returns stdout on
-    /// success, or a `git2::Error` with combined stderr/stdout on failure.
+    /// Run a git command in the given repo directory. Returns stdout
+    /// (trimmed of surrounding whitespace) on success, or an `ApiError` with
+    /// stderr on failure. Use for scalar output such as commit hashes,
+    /// timestamps or porcelain status where trailing newlines are noise.
     fn git(repo_path: &Path, args: &[&str]) -> Result<String, ApiError> {
+        Ok(Self::git_verbatim(repo_path, args)?.trim().to_string())
+    }
+
+    /// Run a git command and return stdout verbatim (no trimming). Use when
+    /// the output is file content whose exact bytes matter -- e.g.
+    /// `git show {commit}:{path}`, whose bytes are hashed to validate
+    /// signatures. Trimming here would alter the hash and break validation.
+    fn git_verbatim(repo_path: &Path, args: &[&str]) -> Result<String, ApiError> {
         let output = std::process::Command::new("git")
             .args(["-C", &repo_path.to_string_lossy()])
             .args(args)
@@ -287,7 +299,7 @@ impl GitCommand {
             )));
         }
 
-        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
     }
 }
 impl Sha256GitBackend {
@@ -758,6 +770,36 @@ mod sha256_tests {
 
         let current = std::fs::read_to_string(&file_path).unwrap();
         assert_eq!(current, r#"{"version": 2}"#);
+    }
+
+    #[test]
+    fn test_sha256_file_content_at_commit_preserves_trailing_newline() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo_path = temp_dir.path();
+        init_sha256_repo(repo_path);
+
+        // A signers file edited by a tool that appends a final newline. The
+        // exact bytes are part of what gets signed, so retrieval must return
+        // them verbatim -- trimming would change the hash and break chain
+        // validation.
+        let file_path = repo_path.join("data.json");
+        let content_with_newline = "{\"version\": 1}\n";
+        std::fs::write(&file_path, content_with_newline).unwrap();
+
+        let backend = Sha256GitBackend::new(repo_path, test_helpers::git_signing_pub_key_path());
+        backend
+            .commit_files(
+                &[normalise_for_repo(repo_path, &file_path)],
+                "add data.json",
+            )
+            .unwrap();
+
+        let first_commit = GitCommand::git(repo_path, &["log", "--format=%H", "-1"]).unwrap();
+
+        let content = backend
+            .file_content_at_commit(&first_commit, Path::new("data.json"))
+            .unwrap();
+        assert_eq!(content, content_with_newline);
     }
 
     #[test]

--- a/tests/e2e_tests/basic_flow_local.sh
+++ b/tests/e2e_tests/basic_flow_local.sh
@@ -75,6 +75,12 @@ cargo run --quiet --manifest-path "$base_dir/client-cli/Cargo.toml" -- new-signe
     -R 2 \
     -o "$FS_PROJECT_DIR/$HIDDEN_SIGNERS_DIR/signers_file_2${_SIGNERS_SUFFIX}.json"
 
+# Append a trailing newline, as a text editor commonly would on save. The exact
+# bytes of the signers file are what gets signed, so chain validation must read
+# them back verbatim -- regression guard against content being trimmed on
+# retrieval from git.
+printf '\n' >> "$FS_PROJECT_DIR/$HIDDEN_SIGNERS_DIR/signers_file_2${_SIGNERS_SUFFIX}.json"
+
 # Generate artifact binaries
 dd if=/dev/urandom of="$FS_PROJECT_DIR/releases/v0.1/artifact.bin" bs=1024 count=4 2>/dev/null
 dd if=/dev/urandom of="$FS_PROJECT_DIR/releases/v0.2/artifact.bin" bs=1024 count=4 2>/dev/null


### PR DESCRIPTION
We discovered that string retrieved from the git backend is trimmed before it is sent to the client, preventing signature validation of the signers file if it had been edited by an editor adding a trailing new line. This removes the trimming, another change will write posix compliant files, i.e. with a trailing new line.