### PR TITLE
Hash display

### DIFF
--- a/admin-lib/src/client/v1.rs
+++ b/admin-lib/src/client/v1.rs
@@ -7,7 +7,9 @@ use features_lib::{
     AsfaloadSignatures,
 };
 use reqwest::header::CONTENT_TYPE;
-use rest_api_types::models::{UpdateRepoSignersRequest, UpdateRepoSignersResponse};
+use rest_api_types::models::{
+    ClientPendingFile, UpdateRepoSignersRequest, UpdateRepoSignersResponse,
+};
 use rest_api_types::{
     FilesToSignResponse, GetSignatureStatusResponse, ListPendingResponse, PingResponse,
     RegisterRepoRequest, RegisterRepoResponse, RevokeFileRequest, RevokeFileResponse,
@@ -190,7 +192,7 @@ impl Client {
     /// auth headers and the request body (avoids signature mismatch).
     pub async fn submit_signatures(
         &self,
-        file_path: &str,
+        pending_file: ClientPendingFile,
         public_key: &AsfaloadPublicKeys,
         signatures: &HashMap<String, AsfaloadSignatures>,
         secret_key: &AsfaloadSecretKeys,
@@ -203,7 +205,7 @@ impl Client {
             .collect();
 
         let request = SubmitSignatureRequest {
-            file_path: file_path.to_string(),
+            pending_file,
             public_key: public_key.to_base64(),
             signatures: sig_map,
         };

--- a/client-cli/src/cli.rs
+++ b/client-cli/src/cli.rs
@@ -189,7 +189,7 @@ pub enum Commands {
         #[arg(requires = "digest")]
         file_path: Option<String>,
 
-        #[arg(long)]
+        #[arg(long, requires = "file_path")]
         digest: Option<String>,
 
         #[command(flatten)]

--- a/client-cli/src/cli.rs
+++ b/client-cli/src/cli.rs
@@ -186,7 +186,11 @@ pub enum Commands {
     /// Sign a pending file (fetch, sign, submit)
     SignPending {
         /// Path to the pending file (relative path in mirror). Prompted for select if missing.
+        #[arg(requires = "digest")]
         file_path: Option<String>,
+
+        #[arg(long)]
+        digest: Option<String>,
 
         #[command(flatten)]
         secret_key_args: SecretKeyArgs,

--- a/client-cli/src/commands.rs
+++ b/client-cli/src/commands.rs
@@ -209,16 +209,17 @@ pub fn handle_command(cli: &Cli) -> Result<()> {
                     // not be worth it.
                     let client = admin_lib::v1::Client::new(url.clone());
                     let response = runtime.block_on(client.get_pending_signatures(&secret_key))?;
-                    let pendings = response.pending_files;
-                    let proposals: Vec<String> = pendings
-                        .iter()
-                        .map(|p| format!("{}\n{}", p.path(), p.digest()))
-                        .collect();
+                    // We use the pending files as the proposals to be able to extract the path easily.
+                    // If we format it in a custom way here, we will get the string as a response,
+                    // and we need to extract the path from that. Much better to work with FilePending.
+                    // Inquired formats them according to the Display implementation for PendingFile,
+                    let proposals = response.pending_files;
+
                     if proposals.is_empty() {
                         return Err(anyhow::Error::new(ClientCliError::NoPendingSignature));
                     } else if std::io::stdin().is_terminal() {
                         match inquire::Select::new("File to sign", proposals).prompt() {
-                            Ok(choice) => choice,
+                            Ok(choice) => choice.path().to_string(),
                             Err(_) => {
                                 return Err(anyhow::Error::new(ClientCliError::InvalidInput(
                                     "Selection cancelled or failed: no path to sign was provided"

--- a/client-cli/src/commands.rs
+++ b/client-cli/src/commands.rs
@@ -209,7 +209,11 @@ pub fn handle_command(cli: &Cli) -> Result<()> {
                     // not be worth it.
                     let client = admin_lib::v1::Client::new(url.clone());
                     let response = runtime.block_on(client.get_pending_signatures(&secret_key))?;
-                    let proposals = response.file_paths;
+                    let pendings = response.pending_files;
+                    let proposals: Vec<String> = pendings
+                        .iter()
+                        .map(|p| format!("{}\n{}", p.path(), p.digest()))
+                        .collect();
                     if proposals.is_empty() {
                         return Err(anyhow::Error::new(ClientCliError::NoPendingSignature));
                     } else if std::io::stdin().is_terminal() {

--- a/client-cli/src/commands.rs
+++ b/client-cli/src/commands.rs
@@ -17,6 +17,7 @@ pub mod signature_status;
 pub mod signers_file;
 use anyhow::Result;
 use features_lib::{AsfaloadSecretKeyTrait, AsfaloadSecretKeys};
+use rest_api_types::models::ClientPendingFile;
 
 pub mod download;
 pub mod ping;
@@ -177,6 +178,7 @@ pub fn handle_command(cli: &Cli) -> Result<()> {
         }
         Commands::SignPending {
             file_path: file_path_in,
+            digest,
             secret_key_args,
             password_args,
             backend_url_args,
@@ -200,8 +202,8 @@ pub fn handle_command(cli: &Cli) -> Result<()> {
                 .unwrap_or_else(|| DEFAULT_BACKEND.to_string());
 
             let runtime = tokio::runtime::Runtime::new()?;
-            let file_path = match file_path_in {
-                Some(p) => p.clone(),
+            let pending_file = match file_path_in {
+                Some(p) => ClientPendingFile::new(p.clone(), digest.clone().unwrap()),
                 None => {
                     // need to select interactively as no path passed on command line.
                     // This path is currently not tested, but it uses tested components.
@@ -209,17 +211,14 @@ pub fn handle_command(cli: &Cli) -> Result<()> {
                     // not be worth it.
                     let client = admin_lib::v1::Client::new(url.clone());
                     let response = runtime.block_on(client.get_pending_signatures(&secret_key))?;
-                    // We use the pending files as the proposals to be able to extract the path easily.
-                    // If we format it in a custom way here, we will get the string as a response,
-                    // and we need to extract the path from that. Much better to work with FilePending.
-                    // Inquired formats them according to the Display implementation for PendingFile,
+                    // Inquired formats proposals according to the Display implementation for PendingFile,
                     let proposals = response.pending_files;
 
                     if proposals.is_empty() {
                         return Err(anyhow::Error::new(ClientCliError::NoPendingSignature));
                     } else if std::io::stdin().is_terminal() {
                         match inquire::Select::new("File to sign", proposals).prompt() {
-                            Ok(choice) => choice.path().to_string(),
+                            Ok(choice) => choice.unseal(),
                             Err(_) => {
                                 return Err(anyhow::Error::new(ClientCliError::InvalidInput(
                                     "Selection cancelled or failed: no path to sign was provided"
@@ -235,7 +234,7 @@ pub fn handle_command(cli: &Cli) -> Result<()> {
                 }
             };
             runtime.block_on(sign_pending::handle_sign_pending_sec_key(
-                &file_path,
+                pending_file,
                 &url,
                 &secret_key,
                 json_args.json,

--- a/client-cli/src/commands/list_pending.rs
+++ b/client-cli/src/commands/list_pending.rs
@@ -1,6 +1,7 @@
 use crate::error::Result;
 use features_lib::AsfaloadSecretKeyTrait;
 use features_lib::AsfaloadSecretKeys;
+use rest_api_types::models::PendingFile;
 
 /// Handle the list-pending command.
 ///
@@ -22,7 +23,7 @@ pub async fn handle_list_pending_command(
     secret_key_path: &std::path::PathBuf,
     password: &str,
     json: bool,
-) -> Result<Vec<String>> {
+) -> Result<Vec<PendingFile>> {
     // 1. Load secret key
     let secret_key = AsfaloadSecretKeys::from_file(secret_key_path, password)?;
 
@@ -33,14 +34,14 @@ pub async fn handle_list_pending_command(
     // 3. Display results
     if json {
         println!("{}", serde_json::to_string(&response)?);
-    } else if response.file_paths.is_empty() {
+    } else if response.pending_files.is_empty() {
         println!("No pending signatures found.");
     } else {
         println!("Files requiring your signature:");
-        for path in &response.file_paths {
+        for path in &response.pending_files {
             println!("  - {}", path);
         }
     }
 
-    Ok(response.file_paths)
+    Ok(response.pending_files)
 }

--- a/client-cli/src/commands/sign_pending.rs
+++ b/client-cli/src/commands/sign_pending.rs
@@ -51,7 +51,7 @@ pub async fn handle_sign_pending_sec_key(
 
     // Fetch all files that need signing
     let files_to_sign = client
-        .fetch_files_to_sign(&pending_file.path(), secret_key)
+        .fetch_files_to_sign(pending_file.path(), secret_key)
         .await?;
 
     // Sign each file
@@ -65,7 +65,7 @@ pub async fn handle_sign_pending_sec_key(
         if *path == pending_file.path() && hash.to_string() != pending_file.digest() {
             return Err(crate::error::ClientCliError::ServerDigestError(
                 hash.to_string(),
-                pending_file.digest(),
+                pending_file.digest().into(),
             ));
         }
         let signature = secret_key.sign(&hash)?;

--- a/client-cli/src/commands/sign_pending.rs
+++ b/client-cli/src/commands/sign_pending.rs
@@ -59,7 +59,10 @@ pub async fn handle_sign_pending_sec_key(
     for (path, content) in &files_to_sign {
         // content is &Vec<u8>, as_slice() give a &[u8] and avoids cloning
         let hash = sha512_for_content(content.as_slice())?;
-        if hash.to_string() != pending_file.digest() {
+        // Only verify the digest for the primary file; associated files (e.g. metadata)
+        // are signed without digest pre-verification since pending_file.digest() covers
+        // only the primary file.
+        if *path == pending_file.path() && hash.to_string() != pending_file.digest() {
             return Err(crate::error::ClientCliError::ServerDigestError(
                 hash.to_string(),
                 pending_file.digest(),

--- a/client-cli/src/commands/sign_pending.rs
+++ b/client-cli/src/commands/sign_pending.rs
@@ -5,7 +5,7 @@ use features_lib::{
     AsfaloadPublicKeyTrait, AsfaloadPublicKeys, AsfaloadSecretKeyTrait, AsfaloadSecretKeys,
     AsfaloadSignatures, sha512_for_content,
 };
-use rest_api_types::SubmitSignatureResponse;
+use rest_api_types::{SubmitSignatureResponse, models::ClientPendingFile};
 
 /// Handle the sign-pending command.
 ///
@@ -28,7 +28,7 @@ use rest_api_types::SubmitSignatureResponse;
 /// * Submit all signatures to backend
 /// * Display result (whether signature is now complete)
 pub async fn handle_sign_pending_command(
-    file_path: &str,
+    pending_file: ClientPendingFile,
     backend_url: &str,
     secret_key_path: &std::path::PathBuf,
     password: &str,
@@ -36,11 +36,11 @@ pub async fn handle_sign_pending_command(
 ) -> Result<SubmitSignatureResponse> {
     // Load secret key and derive public key
     let secret_key = AsfaloadSecretKeys::from_file(secret_key_path, password)?;
-    handle_sign_pending_sec_key(file_path, backend_url, &secret_key, json).await
+    handle_sign_pending_sec_key(pending_file, backend_url, &secret_key, json).await
 }
 
 pub async fn handle_sign_pending_sec_key(
-    file_path: &str,
+    pending_file: ClientPendingFile,
     backend_url: &str,
     secret_key: &AsfaloadSecretKeys,
     json: bool,
@@ -50,20 +50,28 @@ pub async fn handle_sign_pending_sec_key(
     let client = admin_lib::v1::Client::new(backend_url);
 
     // Fetch all files that need signing
-    let files_to_sign = client.fetch_files_to_sign(file_path, secret_key).await?;
+    let files_to_sign = client
+        .fetch_files_to_sign(&pending_file.path(), secret_key)
+        .await?;
 
     // Sign each file
     let mut signatures: HashMap<String, AsfaloadSignatures> = HashMap::new();
     for (path, content) in &files_to_sign {
         // content is &Vec<u8>, as_slice() give a &[u8] and avoids cloning
         let hash = sha512_for_content(content.as_slice())?;
+        if hash.to_string() != pending_file.digest() {
+            return Err(crate::error::ClientCliError::ServerDigestError(
+                hash.to_string(),
+                pending_file.digest(),
+            ));
+        }
         let signature = secret_key.sign(&hash)?;
         signatures.insert(path.clone(), signature);
     }
 
     // Submit all signatures to backend
     let response = client
-        .submit_signatures(file_path, &public_key, &signatures, secret_key)
+        .submit_signatures(pending_file, &public_key, &signatures, secret_key)
         .await?;
 
     // Display result

--- a/client-cli/src/commands/signers_file.rs
+++ b/client-cli/src/commands/signers_file.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use crate::error::{ClientCliError, Result};
 use crate::utils::{ensure_dir_exists, validate_threshold};
-use features_lib::{AsfaloadPublicKeyTrait, AsfaloadPublicKeys, SignersConfig};
+use features_lib::{AsfaloadPublicKeyTrait, AsfaloadPublicKeys, SignersConfig, sha512_for_file};
 
 fn get_group_info<P: AsfaloadPublicKeyTrait>(
     keys: Vec<P>,
@@ -158,6 +158,7 @@ pub fn handle_new_signers_file_command(
     // Print the --json flag output
     let print_json_output =
         |signers_file_destination| -> std::result::Result<(), crate::error::ClientCliError> {
+            let digest = sha512_for_file(&signers_file_destination)?;
             let output = crate::output::NewSignersFileOutput {
                 output_file: signers_file_destination,
                 artifact_signers_count: all_artifact_signers_count,
@@ -168,34 +169,39 @@ pub fn handle_new_signers_file_command(
                 master_threshold,
                 revocation_keys_count: all_revocation_keys_count,
                 revocation_threshold,
+                digest: digest.into(),
             };
             println!("{}", serde_json::to_string(&output)?);
             Ok(())
         };
 
     // Print a human overview of the file written to disk
-    let print_human_overview = |p: &PathBuf| {
-        println!("Signers file created successfully at: {}", p.display());
-        println!(
-            "Artifact signers: {} (threshold: {})",
-            all_artifact_signers_count, artifact_threshold
-        );
-        println!(
-            "Admin keys: {} (threshold: {})",
-            all_admin_keys_count,
-            admin_threshold.map_or("none".to_string(), |t| t.to_string())
-        );
-        println!(
-            "Master keys: {} (threshold: {})",
-            all_master_keys_count,
-            master_threshold.map_or("none".to_string(), |t| t.to_string())
-        );
-        println!(
-            "Revocation keys: {} (threshold: {})",
-            all_revocation_keys_count,
-            revocation_threshold.map_or("none".to_string(), |t| t.to_string())
-        )
-    };
+    let print_human_overview =
+        |p: &PathBuf| -> std::result::Result<(), crate::error::ClientCliError> {
+            let digest = sha512_for_file(p)?;
+            println!("Signers file created successfully at: {}", p.display());
+            println!(
+                "Artifact signers: {} (threshold: {})",
+                all_artifact_signers_count, artifact_threshold
+            );
+            println!(
+                "Admin keys: {} (threshold: {})",
+                all_admin_keys_count,
+                admin_threshold.map_or("none".to_string(), |t| t.to_string())
+            );
+            println!(
+                "Master keys: {} (threshold: {})",
+                all_master_keys_count,
+                master_threshold.map_or("none".to_string(), |t| t.to_string())
+            );
+            println!(
+                "Revocation keys: {} (threshold: {})",
+                all_revocation_keys_count,
+                revocation_threshold.map_or("none".to_string(), |t| t.to_string())
+            );
+            println!("Generated file's digest: {}", digest);
+            Ok(())
+        };
 
     match (output_file, json) {
         // -o and --json
@@ -206,7 +212,7 @@ pub fn handle_new_signers_file_command(
         // -o, no --json
         (Some(p), false) => {
             write_signers_file(p)?;
-            print_human_overview(p)
+            print_human_overview(p)?;
         }
         // no -o, --json
         (None, true) => {

--- a/client-cli/src/error.rs
+++ b/client-cli/src/error.rs
@@ -52,7 +52,7 @@ pub enum ClientCliError {
     #[error("No pending signature found")]
     NoPendingSignature,
 
-    #[error("Unexpected digest from server ({0}) differs from expected ({1})")]
+    #[error("Computed digest ({0}) does not match the digest advertised by the server ({1})")]
     ServerDigestError(String, String),
 }
 

--- a/client-cli/src/error.rs
+++ b/client-cli/src/error.rs
@@ -51,6 +51,9 @@ pub enum ClientCliError {
 
     #[error("No pending signature found")]
     NoPendingSignature,
+
+    #[error("Unexpected digest from server ({0}) differs from expected ({1})")]
+    ServerDigestError(String, String),
 }
 
 // FIXME: remove this, creates more confusion than necessary

--- a/client-cli/src/output.rs
+++ b/client-cli/src/output.rs
@@ -24,6 +24,7 @@ pub struct NewSignersFileOutput {
     pub master_threshold: Option<u32>,
     pub revocation_keys_count: usize,
     pub revocation_threshold: Option<u32>,
+    pub digest: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/client-cli/tests/json_output_test.rs
+++ b/client-cli/tests/json_output_test.rs
@@ -1,6 +1,7 @@
 use features_lib::{AsfaloadKeyPairTrait, AsfaloadKeyPairs};
 use predicates::prelude::*;
 use serde_json::Value;
+use sha2::{Digest, Sha512};
 use std::fs;
 use tempfile::TempDir;
 use test_helpers::fixtures_pub_key;
@@ -104,6 +105,51 @@ fn test_new_signers_file_json_output() {
     assert_eq!(json["master_keys_count"], 0);
     assert!(json["master_threshold"].is_null());
     assert!(!json["output_file"].as_str().unwrap().is_empty());
+}
+
+#[test]
+fn test_new_signers_file_json_digest_present_and_correct() {
+    let pub_key = fixtures_pub_key(0);
+    let temp_dir = TempDir::new().unwrap();
+    let output_file = temp_dir.path().join("signers.json");
+
+    let mut cmd = assert_cmd::cargo_bin_cmd!("asfaload-cli");
+    cmd.arg("new-signers-file")
+        .arg("--json")
+        .arg("--artifact-signers-file")
+        .arg(&pub_key)
+        .arg("-A")
+        .arg("1")
+        .arg("-o")
+        .arg(&output_file);
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let json: Value = serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+
+    let digest_str = json["digest"]
+        .as_str()
+        .expect("digest field should be a string");
+    assert!(!digest_str.is_empty(), "digest should not be empty");
+    assert!(
+        digest_str.starts_with("sha512:"),
+        "digest should start with 'sha512:', got: {}",
+        digest_str
+    );
+
+    let file_bytes = fs::read(&output_file).unwrap();
+    let hash = Sha512::digest(&file_bytes);
+    let expected = format!("sha512:{}", hex::encode(hash));
+    assert_eq!(
+        digest_str, expected,
+        "json digest does not match the file's actual sha512"
+    );
 }
 
 #[test]

--- a/client-cli/tests/signers_file_stdout_test.rs
+++ b/client-cli/tests/signers_file_stdout_test.rs
@@ -1,3 +1,4 @@
+use sha2::{Digest, Sha512};
 use std::fs;
 use tempfile::TempDir;
 use test_helpers::fixtures_pub_key;
@@ -173,6 +174,49 @@ fn json_without_output_file_rejected_by_clap() {
         output.stdout.is_empty(),
         "stdout should be empty on parse failure, got: {}",
         String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+/// With `-o` and no `--json`, the human output must include a "Generated
+/// file's digest:" line whose value is the sha512 of the written file.
+#[test]
+fn digest_printed_and_correct_in_human_output() {
+    let pub_key = fixtures_pub_key(0);
+    let temp_dir = TempDir::new().unwrap();
+    let output_file = temp_dir.path().join("signers.json");
+
+    let mut cmd = assert_cmd::cargo_bin_cmd!("asfaload-cli");
+    cmd.arg("new-signers-file")
+        .arg("--artifact-signers-file")
+        .arg(&pub_key)
+        .arg("-A")
+        .arg("1")
+        .arg("-o")
+        .arg(&output_file);
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    assert!(
+        stdout.contains("Generated file's digest:"),
+        "stdout should contain 'Generated file's digest:', got: {}",
+        stdout
+    );
+
+    let file_bytes = fs::read(&output_file).unwrap();
+    let hash = Sha512::digest(&file_bytes);
+    let expected = format!("sha512:{}", hex::encode(hash));
+    assert!(
+        stdout.contains(&expected),
+        "stdout should contain the sha512 digest '{}', got: {}",
+        expected,
+        stdout
     );
 }
 

--- a/rest-api/src/handlers.rs
+++ b/rest-api/src/handlers.rs
@@ -2,6 +2,7 @@ use common::fs::names::{
     find_global_signers_for, revocation_path_for, revocation_signatures_path_for,
     revocation_signers_path_for, subject_path_from_pending_signatures,
 };
+use common::sha512_for_file;
 use constants::SIGNERS_DIR;
 use features_lib::{AsfaloadPublicKeyTrait, AsfaloadSignatureTrait, SignersConfig};
 use rest_api_types::models::{
@@ -438,6 +439,13 @@ pub async fn submit_signature_handler(
         )));
     }
 
+    // Consistency check of digest sent
+    let digest_on_disk = sha512_for_file(file_path.absolute_path())?;
+    if request.pending_file.digest() != digest_on_disk.to_string() {
+        return Err(ApiError::DigestMismatch(
+            "Digest sent is different from digest of file on disk at path sent.".into(),
+        ));
+    }
     // Parse public key from base64 string
     let public_key = features_lib::AsfaloadPublicKeys::from_base64(&request.public_key)
         .map_err(|_| ApiError::InvalidRequestBody("Invalid public key format".to_string()))?;

--- a/rest-api/src/handlers.rs
+++ b/rest-api/src/handlers.rs
@@ -2,10 +2,11 @@ use common::fs::names::{
     find_global_signers_for, revocation_path_for, revocation_signatures_path_for,
     revocation_signers_path_for, subject_path_from_pending_signatures,
 };
+use common::sha512_for_file;
 use constants::SIGNERS_DIR;
 use features_lib::{AsfaloadPublicKeyTrait, AsfaloadSignatureTrait, SignersConfig};
 use rest_api_types::models::{
-    GetArtifactInfoResponse, UpdateRepoSignersRequest, UpdateRepoSignersResponse,
+    GetArtifactInfoResponse, PendingFile, UpdateRepoSignersRequest, UpdateRepoSignersResponse,
 };
 use rest_api_types::{
     FilesToSignResponse, GetSignatureStatusResponse, GetSignersChainResponse, ListPendingResponse,
@@ -657,12 +658,13 @@ pub async fn get_pending_signatures_handler(
         })?;
 
     // Extract relative paths and convert from pending signature files to artifact files
-    let file_paths: Vec<String> = pending_files
+    let file_paths: Vec<PendingFile> = pending_files
         .iter()
         .map(|np| {
             let pending_sig_path = np.relative_path();
             let artifact_path = subject_path_from_pending_signatures(&pending_sig_path)?;
-            Ok(artifact_path.to_string_lossy().to_string())
+            let r = PendingFile::try_new(artifact_path)?;
+            Ok(r)
         })
         .collect::<Result<Vec<_>, ApiError>>()?;
 
@@ -672,7 +674,9 @@ pub async fn get_pending_signatures_handler(
         "Returning pending signatures list"
     );
 
-    Ok(Json(ListPendingResponse { file_paths }))
+    Ok(Json(ListPendingResponse {
+        pending_files: file_paths,
+    }))
 }
 
 /// Helper to extract public key from authentication headers.

--- a/rest-api/src/handlers.rs
+++ b/rest-api/src/handlers.rs
@@ -419,21 +419,14 @@ pub async fn submit_signature_handler(
 
     tracing::info!(
         request_id = %request_id,
-        file_path = %request.file_path,
+        file_path = %request.pending_file,
         "Received submit_signature request"
     );
-
-    // Validate the file path
-    if request.file_path.is_empty() {
-        return Err(ApiError::InvalidRequestBody(
-            "File path cannot be empty".to_string(),
-        ));
-    }
 
     // Normalize and validate the file path
     let file_path = NormalisedPaths::new(
         state.git_repo_path.clone(),
-        PathBuf::from_str(request.file_path.as_ref()).unwrap(),
+        PathBuf::from(request.pending_file.path()),
     )
     .await?;
 
@@ -441,7 +434,7 @@ pub async fn submit_signature_handler(
     if !file_path.absolute_path().exists() {
         return Err(ApiError::InvalidRequestBody(format!(
             "File not found: {}",
-            request.file_path
+            request.pending_file
         )));
     }
 
@@ -459,11 +452,11 @@ pub async fn submit_signature_handler(
     }
 
     // Verify the primary file has a signature
-    let primary_path = PathBuf::from(&request.file_path);
+    let primary_path = PathBuf::from(&request.pending_file.path());
     if !parsed_signatures.contains_key(&primary_path) {
         return Err(ApiError::InvalidRequestBody(format!(
             "No signature provided for primary file: {}",
-            request.file_path
+            request.pending_file
         )));
     }
 
@@ -484,7 +477,7 @@ pub async fn submit_signature_handler(
 
     tracing::info!(
         request_id = %request_id,
-        file_path = %request.file_path,
+        file_path = %request.pending_file,
         is_complete = collector_result.is_complete,
         "Signature collection result"
     );

--- a/rest-api/src/handlers.rs
+++ b/rest-api/src/handlers.rs
@@ -2,7 +2,6 @@ use common::fs::names::{
     find_global_signers_for, revocation_path_for, revocation_signatures_path_for,
     revocation_signers_path_for, subject_path_from_pending_signatures,
 };
-use common::sha512_for_file;
 use constants::SIGNERS_DIR;
 use features_lib::{AsfaloadPublicKeyTrait, AsfaloadSignatureTrait, SignersConfig};
 use rest_api_types::models::{
@@ -662,8 +661,9 @@ pub async fn get_pending_signatures_handler(
         .iter()
         .map(|np| {
             let pending_sig_path = np.relative_path();
-            let artifact_path = subject_path_from_pending_signatures(&pending_sig_path)?;
-            let r = PendingFile::try_new(artifact_path)?;
+            let artifact_relative = subject_path_from_pending_signatures(&pending_sig_path)?;
+            let artifact_np = build_normalised_absolute_path(np.base_dir(), artifact_relative)?;
+            let r = PendingFile::try_new(&artifact_np)?;
             Ok(r)
         })
         .collect::<Result<Vec<_>, ApiError>>()?;

--- a/rest-api/tests/integration_pending_workflow.rs
+++ b/rest-api/tests/integration_pending_workflow.rs
@@ -55,9 +55,9 @@ async fn test_pending_workflow_end_to_end() -> Result<()> {
     assert_eq!(response1.status(), 200);
 
     let response1_body: ListPendingResponse = response1.json().await?;
-    println!("Pending files for key1: {:?}", response1_body.file_paths);
-    assert_eq!(response1_body.file_paths.len(), 1);
-    assert_eq!(response1_body.file_paths[0], file_path_str);
+    println!("Pending files for key1: {:?}", response1_body.pending_files);
+    assert_eq!(response1_body.pending_files.len(), 1);
+    assert_eq!(response1_body.pending_files[0], file_path_str);
 
     // ===== Test 2: key1 submits signature =====
     let artifact_path = setup.repo_path().join(file_path_str);
@@ -120,9 +120,9 @@ async fn test_pending_workflow_end_to_end() -> Result<()> {
     let response3_body: ListPendingResponse = response3.json().await?;
     println!(
         "Pending files for key1 after signing: {:?}",
-        response3_body.file_paths
+        response3_body.pending_files
     );
-    assert!(response3_body.file_paths.is_empty());
+    assert!(response3_body.pending_files.is_empty());
 
     // ===== Test 4: Verify key2 still sees pending file =====
     let auth_info4 = AuthInfo::new("".to_string());
@@ -144,9 +144,9 @@ async fn test_pending_workflow_end_to_end() -> Result<()> {
     assert_eq!(response4.status(), 200);
 
     let response4_body: ListPendingResponse = response4.json().await?;
-    println!("Pending files for key2: {:?}", response4_body.file_paths);
-    assert_eq!(response4_body.file_paths.len(), 1);
-    assert_eq!(response4_body.file_paths[0], file_path_str);
+    println!("Pending files for key2: {:?}", response4_body.pending_files);
+    assert_eq!(response4_body.pending_files.len(), 1);
+    assert_eq!(response4_body.pending_files[0], file_path_str);
 
     Ok(())
 }

--- a/rest-api/tests/integration_pending_workflow.rs
+++ b/rest-api/tests/integration_pending_workflow.rs
@@ -57,7 +57,7 @@ async fn test_pending_workflow_end_to_end() -> Result<()> {
     let response1_body: ListPendingResponse = response1.json().await?;
     println!("Pending files for key1: {:?}", response1_body.pending_files);
     assert_eq!(response1_body.pending_files.len(), 1);
-    assert_eq!(response1_body.pending_files[0], file_path_str);
+    assert_eq!(response1_body.pending_files[0].path(), file_path_str);
 
     // ===== Test 2: key1 submits signature =====
     let artifact_path = setup.repo_path().join(file_path_str);
@@ -146,7 +146,7 @@ async fn test_pending_workflow_end_to_end() -> Result<()> {
     let response4_body: ListPendingResponse = response4.json().await?;
     println!("Pending files for key2: {:?}", response4_body.pending_files);
     assert_eq!(response4_body.pending_files.len(), 1);
-    assert_eq!(response4_body.pending_files[0], file_path_str);
+    assert_eq!(response4_body.pending_files[0].path(), file_path_str);
 
     Ok(())
 }

--- a/rest-api/tests/integration_pending_workflow.rs
+++ b/rest-api/tests/integration_pending_workflow.rs
@@ -68,7 +68,10 @@ async fn test_pending_workflow_end_to_end() -> Result<()> {
     let mut signatures = std::collections::HashMap::new();
     signatures.insert(file_path_str.to_string(), sig.to_base64());
     let submit_payload = serde_json::json!({
-        "file_path": file_path_str,
+        "pending_file": {
+            "path": file_path_str,
+            "digest": hash.to_string(),
+        },
         "public_key": test_keys.pub_key(0).unwrap().to_base64(),
         "signatures": signatures,
     });

--- a/rest-api/tests/integration_tests.rs
+++ b/rest-api/tests/integration_tests.rs
@@ -1276,6 +1276,62 @@ pub mod test_utils_tests {
     }
 
     #[tokio::test]
+    async fn test_submit_signature_rejects_wrong_digest() -> Result<(), anyhow::Error> {
+        use features_lib::AsfaloadPublicKeyTrait;
+        use rest_api_test_helpers::TestSetupBuilder;
+
+        let setup = TestSetupBuilder::new()
+            .with_artifact("releases/artifact.bin")
+            .build()
+            .await?;
+
+        let public_key = setup.test_keys().pub_key(0).unwrap();
+        let secret_key = setup.test_keys().sec_key(0).unwrap();
+
+        // Valid path, but digest does not match the file on disk
+        let wrong_digest = "sha512:00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        let payload = serde_json::json!({
+            "pending_file": {
+                "path": setup.artifact_path(),
+                "digest": wrong_digest,
+            },
+            "public_key": public_key.to_base64(),
+            "signatures": {
+                setup.artifact_path(): "invalid_signature",
+            },
+        });
+
+        let payload_string = payload.to_string();
+        let auth = create_auth_headers_with_key(secret_key, &payload_string).await;
+
+        let response = setup
+            .client()
+            .post(url_for("signatures", setup.port()))
+            .header(HEADER_TIMESTAMP, &auth.timestamp)
+            .header(HEADER_NONCE, &auth.nonce)
+            .header(HEADER_SIGNATURE, &auth.signature)
+            .header(HEADER_PUBLIC_KEY, &auth.public_key)
+            .json(&payload)
+            .send()
+            .await?;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body: serde_json::Value = response.json().await?;
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap_or("")
+                .to_lowercase()
+                .contains("digest"),
+            "Expected digest mismatch error, got: {}",
+            body
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_revoke_fully_signed_artifact() -> Result<(), anyhow::Error> {
         use features_lib::{
             AsfaloadPublicKeyTrait, AsfaloadSecretKeyTrait, AsfaloadSignatureTrait,

--- a/rest-api/tests/integration_tests.rs
+++ b/rest-api/tests/integration_tests.rs
@@ -1007,6 +1007,7 @@ pub mod test_utils_tests {
         };
         use rest_api_types::SubmitSignatureRequest;
         use rest_api_types::SubmitSignatureResponse;
+        use rest_api_types::models::ClientPendingFile;
         use std::collections::HashMap;
 
         let temp_dir = TempDir::new()?;
@@ -1081,7 +1082,7 @@ pub mod test_utils_tests {
         signatures.insert(signers_rel_path.clone(), signature.to_base64());
         signatures.insert(metadata_rel_path, metadata_signature.to_base64());
         let payload = json!(&SubmitSignatureRequest {
-            file_path: signers_rel_path,
+            pending_file: ClientPendingFile::new(signers_rel_path, digest.to_string()),
             public_key: public_key.to_base64(),
             signatures,
         });
@@ -1235,7 +1236,10 @@ pub mod test_utils_tests {
         rest_api_test_helpers::wait_for_server(&config, None).await?;
 
         let payload = json!({
-            "file_path": "nonexistent.txt",
+            "pending_file": {
+                "path": "nonexistent.txt",
+                "digest": "fake_digest_for_nonexistent_file",
+            },
             "public_key": public_key.to_base64(),
             "signatures": {
                 "nonexistent.txt": "invalid_signature"
@@ -1330,6 +1334,7 @@ pub mod test_utils_tests {
             AsfaloadPublicKeyTrait, AsfaloadSecretKeyTrait, AsfaloadSignatureTrait, sha512_for_file,
         };
         use rest_api_types::SubmitSignatureRequest;
+        use rest_api_types::models::ClientPendingFile;
 
         let temp_dir = TempDir::new()?;
         let git_repo_path = temp_dir.path().join("git_repo");
@@ -1371,7 +1376,10 @@ pub mod test_utils_tests {
         let mut signatures = std::collections::HashMap::new();
         signatures.insert("releases/release.tar.gz".to_string(), signature.to_base64());
         let payload = json!(&SubmitSignatureRequest {
-            file_path: "releases/release.tar.gz".to_string(),
+            pending_file: ClientPendingFile::new(
+                "releases/release.tar.gz".to_string(),
+                digest.to_string()
+            ),
             public_key: public_key.to_base64(),
             signatures,
         });
@@ -1521,19 +1529,28 @@ pub mod test_utils_tests {
             let files_body: rest_api_types::FilesToSignResponse = files_resp.json().await?;
 
             // Sign each file
+            let signers_path_str =
+                format!("{}/asfaload.signers.pending/index.json", project_prefix);
             let mut signatures = std::collections::HashMap::new();
+            let mut signers_digest_str = String::new();
             for (path, content_b64) in &files_body.files {
                 let content =
                     base64::Engine::decode(&base64::engine::general_purpose::STANDARD, content_b64)
                         .expect("base64 decode");
                 let hash = features_lib::sha512_for_content(content)?;
+                if *path == signers_path_str {
+                    signers_digest_str = hash.to_string();
+                }
                 let sig = secret_key.sign(&hash)?;
                 signatures.insert(path.clone(), sig.to_base64());
             }
 
             // Submit signatures
             let submit_body = rest_api_types::SubmitSignatureRequest {
-                file_path: format!("{}/asfaload.signers.pending/index.json", project_prefix),
+                pending_file: rest_api_types::models::ClientPendingFile::new(
+                    signers_path_str,
+                    signers_digest_str,
+                ),
                 public_key: public_key.to_base64(),
                 signatures,
             };

--- a/rest_api_test_helpers/src/lib.rs
+++ b/rest_api_test_helpers/src/lib.rs
@@ -506,7 +506,10 @@ impl TestSetup {
         signatures.insert(self.artifact_path.clone(), sig.to_base64());
 
         let submit_payload = serde_json::json!({
-            "file_path": self.artifact_path,
+            "pending_file": {
+                "path": self.artifact_path,
+                "digest": hash.to_string(),
+            },
             "public_key": public_key.to_base64(),
             "signatures": signatures,
         });

--- a/rest_api_types/src/lib.rs
+++ b/rest_api_types/src/lib.rs
@@ -360,11 +360,11 @@ pub mod models {
         pub fn new(path: String, digest: String) -> ClientPendingFile {
             ClientPendingFile { path, digest }
         }
-        pub fn path(&self) -> String {
-            self.path.clone()
+        pub fn path(&self) -> &str {
+            &self.path
         }
-        pub fn digest(&self) -> String {
-            self.digest.clone()
+        pub fn digest(&self) -> &str {
+            &self.digest
         }
     }
 

--- a/rest_api_types/src/lib.rs
+++ b/rest_api_types/src/lib.rs
@@ -316,11 +316,11 @@ pub mod models {
     /// Request to submit signatures for a specific file.
     ///
     /// # Fields
-    /// * `file_path` - Relative path to the file being signed
+    /// * `pending_file` - relative file path and digest
     /// * `public_key` - Base64-encoded public key of the signer
     /// * `signatures` - Map of file path to base64-encoded signature data
     pub struct SubmitSignatureRequest {
-        pub file_path: String,
+        pub pending_file: ClientPendingFile,
         pub public_key: String,
         pub signatures: HashMap<String, String>,
     }
@@ -345,6 +345,33 @@ pub mod models {
     pub struct GetSignatureStatusResponse {
         pub file_path: String,
         pub is_complete: bool,
+    }
+
+    // This struct can be initialised by the client without access to the file on disk, but it has
+    // to provide the digest of said file.
+    // The PendingFile can only be built for files accessible on disk, by the server.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct ClientPendingFile {
+        pub path: String,
+        pub digest: String,
+    }
+
+    impl ClientPendingFile {
+        pub fn new(path: String, digest: String) -> ClientPendingFile {
+            ClientPendingFile { path, digest }
+        }
+        pub fn path(&self) -> String {
+            self.path.clone()
+        }
+        pub fn digest(&self) -> String {
+            self.digest.clone()
+        }
+    }
+
+    impl fmt::Display for ClientPendingFile {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "path: {}\ndigest: {}\n", self.path(), self.digest())
+        }
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -375,6 +402,15 @@ pub mod models {
         }
         pub fn digest(&self) -> &str {
             &self.digest
+        }
+
+        /// Get a ClientPendingFile from self. Transitions from a verified instance
+        /// (with digest computed from disk) to an untrustable instance (eg received by the server)
+        pub fn unseal(&self) -> ClientPendingFile {
+            ClientPendingFile {
+                path: self.path().into(),
+                digest: self.digest().into(),
+            }
         }
     }
     #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/rest_api_types/src/lib.rs
+++ b/rest_api_types/src/lib.rs
@@ -352,9 +352,12 @@ pub mod models {
         path: String,
         digest: String,
     }
+
+    // The Display implementation is used by Inquire::Select
+    // Changing the format here will change the select prompt used by sign-pending
     impl fmt::Display for PendingFile {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "path: {}, digest: {}", self.path, self.digest)
+            write!(f, "path: {}\n digest: {}\n", self.path, self.digest)
         }
     }
 

--- a/rest_api_types/src/lib.rs
+++ b/rest_api_types/src/lib.rs
@@ -281,7 +281,7 @@ pub mod environment {
 
 pub mod models {
     use core::fmt;
-    use std::{collections::HashMap, path::Path};
+    use std::collections::HashMap;
 
     use common::sha512_for_file;
     use serde::{Deserialize, Serialize};
@@ -359,10 +359,11 @@ pub mod models {
     }
 
     impl PendingFile {
-        pub fn try_new<P: AsRef<Path>>(p: P) -> Result<PendingFile, ApiError> {
-            let path_ref = p.as_ref();
-            let path = path_ref.to_string_lossy().to_string();
-            let digest = sha512_for_file(&path)?.to_string();
+        pub fn try_new(
+            np: &crate::path_validation::NormalisedPaths,
+        ) -> Result<PendingFile, ApiError> {
+            let path = np.relative_path().to_string_lossy().to_string();
+            let digest = sha512_for_file(np.absolute_path())?.to_string();
             Ok(PendingFile { path, digest })
         }
 

--- a/rest_api_types/src/lib.rs
+++ b/rest_api_types/src/lib.rs
@@ -280,9 +280,13 @@ pub mod environment {
 }
 
 pub mod models {
-    use std::collections::HashMap;
+    use core::fmt;
+    use std::{collections::HashMap, path::Path};
 
+    use common::sha512_for_file;
     use serde::{Deserialize, Serialize};
+
+    use crate::errors::ApiError;
 
     #[derive(Debug, Serialize)]
     pub struct ErrorResponse {
@@ -344,13 +348,39 @@ pub mod models {
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct PendingFile {
+        path: String,
+        digest: String,
+    }
+    impl fmt::Display for PendingFile {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "path: {}, digest: {}", self.path, self.digest)
+        }
+    }
+
+    impl PendingFile {
+        pub fn try_new<P: AsRef<Path>>(p: P) -> Result<PendingFile, ApiError> {
+            let path_ref = p.as_ref();
+            let path = path_ref.to_string_lossy().to_string();
+            let digest = sha512_for_file(&path)?.to_string();
+            Ok(PendingFile { path, digest })
+        }
+
+        pub fn path(&self) -> &str {
+            &self.path
+        }
+        pub fn digest(&self) -> &str {
+            &self.digest
+        }
+    }
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     /// Response to a pending signatures list request.
     ///
     /// # Fields
     /// * `file_paths` - List of relative paths to files that need signatures
     ///   from the requesting signer
     pub struct ListPendingResponse {
-        pub file_paths: Vec<String>,
+        pub pending_files: Vec<PendingFile>,
     }
 
     /// Authentication outcome reported by the ping endpoint.

--- a/rest_api_types/src/path_validation.rs
+++ b/rest_api_types/src/path_validation.rs
@@ -551,6 +551,22 @@ mod tests {
 
     use anyhow::Result;
     #[tokio::test]
+    async fn test_new_empty_requested_path_is_rejected() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let base_path = temp_dir.path();
+
+        let result = NormalisedPaths::new(base_path, "").await;
+        match result {
+            Err(ApiError::InvalidFilePath(s)) => {
+                assert_eq!(s, "Requested (relative path) cannot be empty")
+            }
+            Err(e) => panic!("Expected InvalidFilePath, got {}", e),
+            Ok(_) => panic!("Expected InvalidFilePath, got ok result"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_normalised_path_join() -> Result<()> {
         let temp_dir = TempDir::new().unwrap();
         let base_path = temp_dir.path();

--- a/rest_api_types/src/path_validation.rs
+++ b/rest_api_types/src/path_validation.rs
@@ -22,10 +22,17 @@ pub struct NormalisedPaths {
 impl NormalisedPaths {
     pub async fn new<P1: AsRef<Path>, P2: AsRef<Path>>(
         base_repo_path: P1,
-        requested_path: P2,
+        requested_path_in: P2,
     ) -> Result<Self, ApiError> {
+        let requested_path = requested_path_in.as_ref();
+        if requested_path.as_os_str().is_empty() {
+            return Err(ApiError::InvalidFilePath(
+                "Requested (relative path) cannot be empty".into(),
+            ));
+        }
         let base_path = base_repo_path.as_ref().to_path_buf();
-        let req_path = requested_path.as_ref().to_path_buf();
+        let req_path = requested_path.to_path_buf();
+
         tokio::task::spawn_blocking(move || Self::new_sync(base_path, req_path))
             .await
             .map_err(ApiError::from)?

--- a/tests/client-server-integration-tests/tests/integration_tests.rs
+++ b/tests/client-server-integration-tests/tests/integration_tests.rs
@@ -274,6 +274,98 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_sign_pending_server_digest_mismatch() {
+        use client_cli::error::ClientCliError;
+        use rest_api_types::models::ClientPendingFile;
+
+        let state = test_harness::initialize().await;
+        let guard = state.lock().await;
+        let git_repo_path = guard.server.git_repo_path();
+        let secret_key_path = guard.secret_key_paths[0].clone();
+        let backend_url = guard.server.base_url();
+        drop(guard);
+
+        let secret_key = features_lib::AsfaloadSecretKeys::from_file(
+            &secret_key_path,
+            test_harness::TEST_PASSWORD,
+        )
+        .expect("Failed to load secret key");
+        let public_key = features_lib::AsfaloadPublicKeys::from_secret_key(&secret_key)
+            .expect("Failed to derive public key");
+
+        let (project_dir_sub, file_path) =
+            test_harness::unique_test_paths("sign_pending_digest_mismatch", "artifact.txt");
+        let project_dir = git_repo_path.join(&project_dir_sub);
+        fs::create_dir_all(&project_dir).expect("Failed to create project dir");
+
+        let signers_config =
+            SignersConfig::with_artifact_signers_only(1, (vec![public_key.clone()], 1))
+                .expect("Failed to build signers config");
+        let signers_content = signers_config
+            .to_json()
+            .expect("Failed to serialize signers config");
+
+        initialize_signers_file_with_pending_sigs(&project_dir, &signers_content, &public_key);
+
+        // Sign the pending signers file to activate it
+        let file_paths = client_cli::commands::list_pending::handle_list_pending_command(
+            &backend_url,
+            &secret_key_path,
+            test_harness::TEST_PASSWORD,
+            false,
+        )
+        .await
+        .expect("list-pending should succeed");
+
+        let signers_pending_path = file_paths
+            .iter()
+            .find(|pending| {
+                let p = pending.path();
+                p.contains(project_dir_sub.to_string_lossy().as_ref())
+                    && p.contains(PENDING_SIGNERS_DIR)
+            })
+            .expect("Signers file should be in pending list")
+            .clone();
+
+        client_cli::commands::sign_pending::handle_sign_pending_command(
+            signers_pending_path.unseal(),
+            &backend_url,
+            &secret_key_path,
+            test_harness::TEST_PASSWORD,
+            false,
+        )
+        .await
+        .expect("sign-pending for signers should succeed");
+
+        // Create artifact and its pending signatures file
+        test_harness::create_file_in_repo(&file_path, "artifact content")
+            .await
+            .expect("Failed to create artifact file");
+        test_harness::create_pending_signatures_for(&file_path)
+            .await
+            .expect("Failed to create pending signatures file");
+
+        // Supply the correct path but a wrong digest — simulates a tampered or
+        // mismatched server response
+        let tampered = ClientPendingFile::new(file_path.clone(), "wrongdigest".to_string());
+
+        let err = client_cli::commands::sign_pending::handle_sign_pending_sec_key(
+            tampered,
+            &backend_url,
+            &secret_key,
+            false,
+        )
+        .await
+        .expect_err("Should fail due to digest mismatch");
+
+        assert!(
+            matches!(err, ClientCliError::ServerDigestError(..)),
+            "Expected ServerDigestError, got: {:?}",
+            err
+        );
+    }
+
     // ========================================
     // MULTI-SIGNER WORKFLOW TEST
     // ========================================

--- a/tests/client-server-integration-tests/tests/integration_tests.rs
+++ b/tests/client-server-integration-tests/tests/integration_tests.rs
@@ -106,7 +106,8 @@ mod tests {
 
         let signers_pending_path = file_paths
             .iter()
-            .find(|p| {
+            .find(|pending| {
+                let p = pending.path();
                 p.contains(project_dir_sub.to_string_lossy().as_ref())
                     && p.contains(PENDING_SIGNERS_DIR)
             })
@@ -115,7 +116,7 @@ mod tests {
 
         // Sign the pending signers file to activate it (threshold=all for InitialSignersFile)
         let r = client_cli::commands::sign_pending::handle_sign_pending_command(
-            &signers_pending_path,
+            signers_pending_path.path(),
             &backend_url,
             &secret_key_path,
             test_harness::TEST_PASSWORD,
@@ -147,7 +148,7 @@ mod tests {
         .expect("list-pending should succeed");
 
         assert!(
-            file_paths.iter().any(|p| p == &file_path),
+            file_paths.iter().any(|p| p.path() == file_path),
             "Expected pending list to contain '{}', got: {:?}",
             file_path,
             file_paths
@@ -202,7 +203,8 @@ mod tests {
 
         let signers_pending_path = file_paths
             .iter()
-            .find(|p| {
+            .find(|pending| {
+                let p = pending.path();
                 p.contains(project_dir_sub.to_string_lossy().as_ref())
                     && p.contains(PENDING_SIGNERS_DIR)
             })
@@ -210,7 +212,7 @@ mod tests {
             .clone();
 
         let r = client_cli::commands::sign_pending::handle_sign_pending_command(
-            &signers_pending_path,
+            signers_pending_path.path(),
             &backend_url,
             &secret_key_path,
             test_harness::TEST_PASSWORD,
@@ -243,7 +245,7 @@ mod tests {
         .expect("list-pending should succeed");
 
         assert!(
-            file_paths.iter().any(|p| p == &file_path),
+            file_paths.iter().any(|p| p.path() == file_path),
             "Expected '{}' in pending list, got: {:?}",
             file_path,
             file_paths
@@ -314,7 +316,8 @@ mod tests {
         // Find the signers file for this project in the pending list
         let signers_pending_path = file_paths
             .iter()
-            .find(|p| {
+            .find(|pending| {
+                let p = pending.path();
                 p.contains(project_dir_sub.to_string_lossy().as_ref())
                     && p.contains(PENDING_SIGNERS_DIR)
             })
@@ -323,7 +326,7 @@ mod tests {
 
         // sign-pending with key[0]: 1 of 3, not yet complete
         let r0 = client_cli::commands::sign_pending::handle_sign_pending_command(
-            &signers_pending_path,
+            signers_pending_path.path(),
             &backend_url,
             &key_paths[0],
             test_harness::TEST_PASSWORD,
@@ -338,7 +341,7 @@ mod tests {
 
         // sign-pending with key[1]: 2 of 3, not yet complete
         let r1 = client_cli::commands::sign_pending::handle_sign_pending_command(
-            &signers_pending_path,
+            signers_pending_path.path(),
             &backend_url,
             &key_paths[1],
             test_harness::TEST_PASSWORD,
@@ -353,7 +356,7 @@ mod tests {
 
         // sign-pending with key[2]: 3 of 3, complete -> signers activate
         let r2 = client_cli::commands::sign_pending::handle_sign_pending_command(
-            &signers_pending_path,
+            signers_pending_path.path(),
             &backend_url,
             &key_paths[2],
             test_harness::TEST_PASSWORD,
@@ -385,7 +388,7 @@ mod tests {
         .expect("list-pending should succeed for key[0]");
 
         assert!(
-            file_paths.iter().any(|p| p == &artifact_path),
+            file_paths.iter().any(|p| p.path() == artifact_path),
             "Expected artifact '{}' in pending list, got: {:?}",
             artifact_path,
             file_paths

--- a/tests/client-server-integration-tests/tests/integration_tests.rs
+++ b/tests/client-server-integration-tests/tests/integration_tests.rs
@@ -116,7 +116,7 @@ mod tests {
 
         // Sign the pending signers file to activate it (threshold=all for InitialSignersFile)
         let r = client_cli::commands::sign_pending::handle_sign_pending_command(
-            signers_pending_path.path(),
+            signers_pending_path.unseal(),
             &backend_url,
             &secret_key_path,
             test_harness::TEST_PASSWORD,
@@ -212,7 +212,7 @@ mod tests {
             .clone();
 
         let r = client_cli::commands::sign_pending::handle_sign_pending_command(
-            signers_pending_path.path(),
+            signers_pending_path.unseal(),
             &backend_url,
             &secret_key_path,
             test_harness::TEST_PASSWORD,
@@ -252,8 +252,14 @@ mod tests {
         );
 
         // Sign the pending file
+        let artifact_client_file = file_paths
+            .iter()
+            .find(|p| p.path() == file_path)
+            .expect("file should be in pending list")
+            .clone()
+            .unseal();
         let sign_response = client_cli::commands::sign_pending::handle_sign_pending_command(
-            &file_path,
+            artifact_client_file,
             &backend_url,
             &secret_key_path,
             test_harness::TEST_PASSWORD,
@@ -326,7 +332,7 @@ mod tests {
 
         // sign-pending with key[0]: 1 of 3, not yet complete
         let r0 = client_cli::commands::sign_pending::handle_sign_pending_command(
-            signers_pending_path.path(),
+            signers_pending_path.unseal(),
             &backend_url,
             &key_paths[0],
             test_harness::TEST_PASSWORD,
@@ -341,7 +347,7 @@ mod tests {
 
         // sign-pending with key[1]: 2 of 3, not yet complete
         let r1 = client_cli::commands::sign_pending::handle_sign_pending_command(
-            signers_pending_path.path(),
+            signers_pending_path.unseal(),
             &backend_url,
             &key_paths[1],
             test_harness::TEST_PASSWORD,
@@ -356,7 +362,7 @@ mod tests {
 
         // sign-pending with key[2]: 3 of 3, complete -> signers activate
         let r2 = client_cli::commands::sign_pending::handle_sign_pending_command(
-            signers_pending_path.path(),
+            signers_pending_path.unseal(),
             &backend_url,
             &key_paths[2],
             test_harness::TEST_PASSWORD,
@@ -394,9 +400,16 @@ mod tests {
             file_paths
         );
 
+        let artifact_client_file = file_paths
+            .iter()
+            .find(|p| p.path() == artifact_path)
+            .expect("artifact should be in pending list")
+            .clone()
+            .unseal();
+
         // sign with key[0]: 1 of 2, not complete
         let r3 = client_cli::commands::sign_pending::handle_sign_pending_command(
-            &artifact_path,
+            artifact_client_file.clone(),
             &backend_url,
             &key_paths[0],
             test_harness::TEST_PASSWORD,
@@ -411,7 +424,7 @@ mod tests {
 
         // sign with key[1]: 2 of 2, complete
         let r4 = client_cli::commands::sign_pending::handle_sign_pending_command(
-            &artifact_path,
+            artifact_client_file.clone(),
             &backend_url,
             &key_paths[1],
             test_harness::TEST_PASSWORD,
@@ -426,7 +439,7 @@ mod tests {
 
         // --- Phase 5: Signing after completion should error ---
         let r5 = client_cli::commands::sign_pending::handle_sign_pending_command(
-            &artifact_path,
+            artifact_client_file.clone(),
             &backend_url,
             &key_paths[2],
             test_harness::TEST_PASSWORD,

--- a/tests/e2e_tests/basic_flow.sh
+++ b/tests/e2e_tests/basic_flow.sh
@@ -121,7 +121,7 @@ section "Signers File Activation"
 ################################################################################
 
 run_step_json "List pending for key0 (should show pending signers)" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_0" -u "$backend" --password $key_password
 
 run_step_json "Sign signers file with key0 (submitter signs in second phase)" \
@@ -135,7 +135,7 @@ assert_pending_metadata_signature_count 1
 assert_pending_metadata_signatures_contain_keys "$KEY_0"
 
 run_step_json "List pending for key1" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_1" -u "$backend" --password $key_password
 run_step_json "Sign signers file with key1" \
     '.is_complete == false' \
@@ -182,7 +182,7 @@ expect_fail "Download unsigned artifact (v0.1, 0 signatures)" \
     cargo run --quiet -- download -o "$tmp" -u "$backend" $(artifact_url 0.1)
 
 run_step_json "List pending for key3" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_2" -u "$backend" --password $key_password
 
 run_step_json "Sign release index with key1" \
@@ -245,7 +245,7 @@ assert_pending_metadata_signature_count 0
 assert_pending_signers_contain_keys "$KEY_0" "$KEY_1" "$KEY_2" "$KEY_3"
 
 run_step_json "List pending for key0 (should show pending signers)" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_0" -u "$backend" --password $key_password
 
 run_step_json "Sign pending signers with key0" \
@@ -261,7 +261,7 @@ expect_fail "Attempts to re-sign pending signers with key0 (should fail)" \
     cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $(pending_signers_file)
 
 run_step_json "List pending for key1 (should show pending)" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_1" -u "$backend" --password $key_password
 
 run_step_json "Sign pending signers with key1" \
@@ -318,7 +318,7 @@ assert_release_index_exists "0.2"
 assert_release_index_pending "0.2"
 
 run_step_json "List pending for key3" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_2" -u "$backend" --password $key_password
 
 run_step_json "Sign release index with key1" \
@@ -366,11 +366,11 @@ run_step "Download artifact (v0.1), not yet revoked as need 2 signatures" \
 assert_artifact_hash_matches "0.1" "artifact.bin" "$DOWNLOAD_V01_bis"
 
 run_step_json "List pending for key1 (none expected, key1 cannot revoke)" \
-    '.file_paths | length == 0' \
+    '.pending_files | length == 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_0" -u "$backend" --password $key_password
 
 run_step_json "List pending for key5 (one expected, key1 can revoke)" \
-    '.file_paths | length == 1' \
+    '.pending_files | length == 1' \
     cargo run --quiet -- list-pending --secret-key "$KEY_5" -u "$backend" --password $key_password
 
 run_step "sign pending revocation for v0.1 (second signer via sign-pending)" \

--- a/tests/e2e_tests/basic_flow_local.sh
+++ b/tests/e2e_tests/basic_flow_local.sh
@@ -226,7 +226,7 @@ section "Signers File Activation"
 ################################################################################
 
 run_step_json "List pending for key0 (should show pending signers)" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_0" -u "$backend" --password $key_password
 
 run_step_json "Sign signers file with key0 (submitter signs in second phase)" \
@@ -240,7 +240,7 @@ assert_pending_metadata_signature_count 1
 assert_pending_metadata_signatures_contain_keys "$KEY_0"
 
 run_step_json "List pending for key1" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_1" -u "$backend" --password $key_password
 run_step_json "Sign signers file with key1" \
     '.is_complete == false' \
@@ -294,7 +294,7 @@ expect_fail "Download unsigned artifact (v0.1, 0 signatures)" \
     cargo run --quiet -- download -o "$tmp" -u "$backend" --type fileserver $(artifact_url 0.1)
 
 run_step_json "List pending for key2" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_2" -u "$backend" --password $key_password
 
 run_step_json "Sign release index with key0" \
@@ -357,7 +357,7 @@ assert_pending_metadata_signature_count 0
 assert_pending_signers_contain_keys "$KEY_0" "$KEY_1" "$KEY_2" "$KEY_3"
 
 run_step_json "List pending for key0 (should show pending signers)" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_0" -u "$backend" --password $key_password
 
 run_step_json "Sign pending signers with key0" \
@@ -373,7 +373,7 @@ expect_fail "Attempts to re-sign pending signers with key0 (should fail)" \
     cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $(pending_signers_file)
 
 run_step_json "List pending for key1 (should show pending)" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_1" -u "$backend" --password $key_password
 
 run_step_json "Sign pending signers with key1" \
@@ -430,7 +430,7 @@ assert_release_index_exists "0.2"
 assert_release_index_pending "0.2"
 
 run_step_json "List pending for key2" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_2" -u "$backend" --password $key_password
 
 run_step_json "Sign release index with key0" \
@@ -478,11 +478,11 @@ run_step "Download artifact (v0.1), not yet revoked as need 2 signatures" \
 assert_artifact_hash_matches "0.1" "artifact.bin" "$DOWNLOAD_V01_bis"
 
 run_step_json "List pending for key0 (none expected, key0 cannot revoke)" \
-    '.file_paths | length == 0' \
+    '.pending_files | length == 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_0" -u "$backend" --password $key_password
 
 run_step_json "List pending for key5 (one expected, key5 can revoke)" \
-    '.file_paths | length == 1' \
+    '.pending_files | length == 1' \
     cargo run --quiet -- list-pending --secret-key "$KEY_5" -u "$backend" --password $key_password
 
 run_step "sign pending revocation for v0.1 (second signer via sign-pending)" \

--- a/tests/e2e_tests/basic_flow_local.sh
+++ b/tests/e2e_tests/basic_flow_local.sh
@@ -229,9 +229,11 @@ run_step_json "List pending for key0 (should show pending signers)" \
     '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_0" -u "$backend" --password $key_password
 
+SIGNERS_SIGN_ARGS=$(pending_signers_sign_args "$KEY_0" "$backend" $key_password)
+
 run_step_json "Sign signers file with key0 (submitter signs in second phase)" \
     '.is_complete == false' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 # --- Backend: verify 1st signature on pending signers and metadata ---
 assert_pending_signers_signature_count 1
@@ -244,7 +246,7 @@ run_step_json "List pending for key1" \
     cargo run --quiet -- list-pending --secret-key "$KEY_1" -u "$backend" --password $key_password
 run_step_json "Sign signers file with key1" \
     '.is_complete == false' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_1" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_1" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 # --- Backend: verify 2nd signature on pending signers and metadata ---
 assert_pending_signers_signature_count 2
@@ -254,14 +256,14 @@ assert_pending_metadata_signatures_contain_keys "$KEY_0" "$KEY_1"
 
 run_step_json "Sign signers file with key2 (completes signature)" \
     '.is_complete == true' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_2" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_2" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 # --- Backend: verify signers activated ---
 assert_signers_active
 assert_signers_contain_keys "$KEY_0" "$KEY_1" "$KEY_2"
 
 expect_fail "Sign signers file with key0 (already completed)" \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 # Test interactive sign-pending when no pending signature is available:
 # no file_path arg triggers the interactive path, which fetches pending
@@ -297,9 +299,11 @@ run_step_json "List pending for key2" \
     '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_2" -u "$backend" --password $key_password
 
+RELEASE_0_1_SIGN_ARGS=$(release_index_sign_args 0.1 "$KEY_0" "$backend" $key_password)
+
 run_step_json "Sign release index with key0" \
     '.is_complete == false' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $(release_index 0.1)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $RELEASE_0_1_SIGN_ARGS
 
 assert_release_index_signature_count "0.1" 1
 
@@ -320,7 +324,7 @@ assert_release_index_signature_count "0.1" 1
 
 run_step_json "Sign release index with key1 (completes, threshold=2)" \
     '.is_complete == true' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_1" -u "$backend" --password $key_password $(release_index 0.1)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_1" -u "$backend" --password $key_password $RELEASE_0_1_SIGN_ARGS
 
 # --- Backend: verify release index activated ---
 assert_release_index_active "0.1"
@@ -331,7 +335,7 @@ run_step_json "Check signature status for v0.1 index (complete)" \
     cargo run --quiet -- signature-status --secret-key "$KEY_0" -u "$backend" --password $key_password $(release_index 0.1)
 
 expect_fail "Sign release index with key2 (already completed)" \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_2" -u "$backend" --password $key_password $(release_index 0.1)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_2" -u "$backend" --password $key_password $RELEASE_0_1_SIGN_ARGS
 
 DOWNLOAD_V01="$(mktemp)"
 to_delete_on_filesystem+=("$DOWNLOAD_V01")
@@ -360,9 +364,11 @@ run_step_json "List pending for key0 (should show pending signers)" \
     '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_0" -u "$backend" --password $key_password
 
+SIGNERS_SIGN_ARGS=$(pending_signers_sign_args "$KEY_0" "$backend" $key_password)
+
 run_step_json "Sign pending signers with key0" \
     '.is_complete == false' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 assert_pending_signers_signature_count 1
 assert_pending_signers_signatures_contain_keys "$KEY_0"
@@ -370,7 +376,7 @@ assert_pending_metadata_signature_count 1
 assert_pending_metadata_signatures_contain_keys "$KEY_0"
 
 expect_fail "Attempts to re-sign pending signers with key0 (should fail)" \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 run_step_json "List pending for key1 (should show pending)" \
     '.pending_files | length > 0' \
@@ -378,7 +384,7 @@ run_step_json "List pending for key1 (should show pending)" \
 
 run_step_json "Sign pending signers with key1" \
     '.is_complete == false' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_1" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_1" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 assert_pending_signers_signature_count 2
 assert_pending_signers_signatures_contain_keys "$KEY_0" "$KEY_1"
@@ -387,7 +393,7 @@ assert_pending_metadata_signatures_contain_keys "$KEY_0" "$KEY_1"
 
 run_step_json "Sign pending signers with key3 (newly added artifact signer)" \
     '.is_complete == false' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_3" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_3" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 assert_pending_signers_signature_count 3
 assert_pending_signers_signatures_contain_keys "$KEY_0" "$KEY_1" "$KEY_3"
@@ -396,15 +402,15 @@ assert_pending_metadata_signatures_contain_keys "$KEY_0" "$KEY_1" "$KEY_3"
 
 run_step_json "Sign pending signers with key4 (newly added revocation key)" \
     '.is_complete == false' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_4" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_4" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 run_step_json "Sign pending signers with key5 (newly added revocation key)" \
     '.is_complete == false' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_5" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_5" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 run_step_json "Sign pending signers with key6 (activates new signers file)" \
     '.is_complete == true' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_6" -u "$backend" --password $key_password $(pending_signers_file)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_6" -u "$backend" --password $key_password $SIGNERS_SIGN_ARGS
 
 # --- Backend: verify new signers activated ---
 assert_signers_active
@@ -433,21 +439,23 @@ run_step_json "List pending for key2" \
     '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_2" -u "$backend" --password $key_password
 
+RELEASE_0_2_SIGN_ARGS=$(release_index_sign_args 0.2 "$KEY_0" "$backend" $key_password)
+
 run_step_json "Sign release index with key0" \
     '.is_complete == false' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $(release_index 0.2)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_0" -u "$backend" --password $key_password $RELEASE_0_2_SIGN_ARGS
 
 assert_release_index_signature_count "0.2" 1
 
 run_step_json "Sign release index with key1" \
     '.is_complete == false' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_1" -u "$backend" --password $key_password $(release_index 0.2)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_1" -u "$backend" --password $key_password $RELEASE_0_2_SIGN_ARGS
 
 assert_release_index_signature_count "0.2" 2
 
 run_step_json "Sign release index with key3 (key2 does not sign)" \
     '.is_complete == true' \
-    cargo run --quiet -- sign-pending --secret-key "$KEY_3" -u "$backend" --password $key_password $(release_index 0.2)
+    cargo run --quiet -- sign-pending --secret-key "$KEY_3" -u "$backend" --password $key_password $RELEASE_0_2_SIGN_ARGS
 
 # --- Backend: verify v0.2 release index activated ---
 assert_release_index_active "0.2"
@@ -485,8 +493,9 @@ run_step_json "List pending for key5 (one expected, key5 can revoke)" \
     '.pending_files | length == 1' \
     cargo run --quiet -- list-pending --secret-key "$KEY_5" -u "$backend" --password $key_password
 
+REVOCATION_SIGN_ARGS=$(pending_sign_args "$REVOCATION_SUFFIX" "$KEY_5" "$backend" $key_password)
 run_step "sign pending revocation for v0.1 (second signer via sign-pending)" \
-    cargo run -- sign-pending --secret-key "$KEY_5" -p $key_password -u "$backend" "$(release_index 0.1).$REVOCATION_SUFFIX.$PENDING_SUFFIX"
+    cargo run -- sign-pending --secret-key "$KEY_5" -p $key_password -u "$backend" $REVOCATION_SIGN_ARGS
 
 # --- Backend: verify v0.1 revoked ---
 assert_release_index_revoked "0.1"

--- a/tests/e2e_tests/lib/helpers.sh
+++ b/tests/e2e_tests/lib/helpers.sh
@@ -285,6 +285,50 @@ expect_fail_json() {
     EXPECTED_FAIL_COUNT=$((EXPECTED_FAIL_COUNT + 1))
 }
 
+# ── Pending-file sign helpers ──────────────────────────────────────────────────
+#
+# Query list-pending and return "PATH --digest DIGEST", ready to append to a
+# sign-pending invocation.  The three tokens are word-split by the caller;
+# paths and SHA-512 hex digests contain no spaces, so this is safe.
+
+# Get sign-pending args for a pending file matching a substring pattern.
+# Usage: args=$(pending_sign_args PATTERN KEY BACKEND PASSWORD)
+#        cargo run -- sign-pending ... $args
+pending_sign_args() {
+    local pattern="$1" key="$2" url="$3" pass="$4"
+    local json path digest
+    json=$(cargo run --quiet -- list-pending \
+        --secret-key "$key" -u "$url" --password "$pass" --json 2>/dev/null)
+    path=$(echo "$json" | jq -r \
+        ".pending_files[] | select(.path | contains(\"$pattern\")) | .path" \
+        | head -1)
+    digest=$(echo "$json" | jq -r \
+        ".pending_files[] | select(.path | contains(\"$pattern\")) | .digest" \
+        | head -1)
+    printf '%s --digest %s' "$path" "$digest"
+}
+
+# Get sign-pending args for the pending signers file.
+# Usage: args=$(pending_signers_sign_args KEY BACKEND PASSWORD)
+#        cargo run -- sign-pending ... $args
+pending_signers_sign_args() {
+    pending_sign_args "$PENDING_SIGNERS_DIR" "$1" "$2" "$3"
+}
+
+# Get sign-pending args for a release index file.
+# Usage: args=$(release_index_sign_args VERSION KEY BACKEND PASSWORD)
+#        cargo run -- sign-pending ... $args
+release_index_sign_args() {
+    local version="$1" key="$2" url="$3" pass="$4"
+    local idx_path json path digest
+    idx_path=$(release_index "$version")
+    json=$(cargo run --quiet -- list-pending \
+        --secret-key "$key" -u "$url" --password "$pass" --json 2>/dev/null)
+    path=$(echo "$json" | jq -r ".pending_files[] | select(.path == \"$idx_path\") | .path")
+    digest=$(echo "$json" | jq -r ".pending_files[] | select(.path == \"$idx_path\") | .digest")
+    printf '%s --digest %s' "$path" "$digest"
+}
+
 print_summary() {
     local script_end total_elapsed
     script_end=$(date +%s)

--- a/tests/e2e_tests/signers_update_by_master.sh
+++ b/tests/e2e_tests/signers_update_by_master.sh
@@ -116,7 +116,7 @@ section "Initial Signers File Activation"
 ################################################################################
 
 run_step_json "List pending for key0 (should show pending signers)" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_0" -u "$backend" --password $key_password
 
 run_step_json "Sign signers file with key0" \
@@ -129,7 +129,7 @@ assert_pending_metadata_signature_count 1
 assert_pending_metadata_signatures_contain_keys "$KEY_0"
 
 run_step_json "List pending for key1" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_1" -u "$backend" --password $key_password
 
 run_step_json "Sign signers file with key1" \
@@ -185,11 +185,11 @@ assert_pending_signers_contain_keys "$KEY_5" "$KEY_6" "$KEY_7"
 assert_pending_signers_contain_master_keys "$KEY_8" "$KEY_9"
 
 run_step_json "List pending for key3 (should show pending signers)" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_3" -u "$backend" --password $key_password
 
 run_step_json "List pending for key5 (should show pending)" \
-    '.file_paths | length > 0' \
+    '.pending_files | length > 0' \
     cargo run --quiet -- list-pending --secret-key "$KEY_5" -u "$backend" --password $key_password
 
 ################################################################################

--- a/tests/e2e_tests/ssh_keys_flow_local.sh
+++ b/tests/e2e_tests/ssh_keys_flow_local.sh
@@ -235,16 +235,13 @@ run_step "Pending signers contains SSH pubkey 2" \
 section "Activate pending signers (both SSH keys sign)"
 ################################################################################
 
-# Backend path identifier for the pending signers file (same shape as
-# urls_local.sh::pending_signers_file but derived from the file-server
-# origin we already have).
-PENDING_SIGNERS_ID="http/localhost/${FILE_SERVER_PORT}/${FS_PROJECT_NAME}/${PENDING_SIGNERS_DIR}/${SIGNERS_FILE}"
+SIGNERS_SIGN_ARGS=$(pending_signers_sign_args "$SSH_KEY_1" "$backend" "$key_password")
 
 run_step_json "Sign pending signers with SSH key 1 (1st of 2)" \
     '.is_complete == false' \
     cargo run --quiet -- sign-pending \
         --secret-key "$SSH_KEY_1" -u "$backend" --password "$key_password" \
-        "$PENDING_SIGNERS_ID"
+        $SIGNERS_SIGN_ARGS
 
 assert_pending_signers_signature_count 1
 assert_pending_metadata_signature_count 1
@@ -257,7 +254,7 @@ run_step_json "Sign pending signers with SSH key 2 (threshold met, activates)" \
     '.is_complete == true' \
     cargo run --quiet -- sign-pending \
         --secret-key "$SSH_KEY_2" -u "$backend" --password "$key_password" \
-        "$PENDING_SIGNERS_ID"
+        $SIGNERS_SIGN_ARGS
 
 # Backend: signers are now active.
 assert_signers_active
@@ -289,8 +286,6 @@ printf 'asfaload ssh e2e artifact v%s' "$RELEASE_VERSION" > "$RELEASE_DIR_ON_FS/
 
 CSUM_URL="${FILE_SERVER_URL}/${FS_PROJECT_NAME}/releases/v${RELEASE_VERSION}/SHA256SUMS"
 ARTIFACT_URL="${FILE_SERVER_URL}/${FS_PROJECT_NAME}/releases/v${RELEASE_VERSION}/${ARTIFACT_NAME}"
-RELEASE_INDEX_ID="http/localhost/${FILE_SERVER_PORT}/${FS_PROJECT_NAME}/releases/v${RELEASE_VERSION}/${INDEX_FILE}"
-
 run_step_json "Register release via SHA256SUMS (SSH key 1 as submitter)" \
     '.success == true' \
     cargo run --quiet -- register-assets \
@@ -301,6 +296,8 @@ assert_release_index_exists "$RELEASE_VERSION"
 assert_release_index_pending "$RELEASE_VERSION"
 assert_last_commit_contains "$INDEX_FILE"
 
+RELEASE_SIGN_ARGS=$(release_index_sign_args "$RELEASE_VERSION" "$SSH_KEY_1" "$backend" "$key_password")
+
 ################################################################################
 section "Sign release index with both SSH keys"
 ################################################################################
@@ -309,7 +306,7 @@ run_step_json "Sign release index with SSH key 1" \
     '.is_complete == false' \
     cargo run --quiet -- sign-pending \
         --secret-key "$SSH_KEY_1" -u "$backend" --password "$key_password" \
-        "$RELEASE_INDEX_ID"
+        $RELEASE_SIGN_ARGS
 
 assert_release_index_signature_count "$RELEASE_VERSION" 1
 
@@ -321,7 +318,7 @@ run_step_json "Sign release index with SSH key 2 (threshold met, activates)" \
     '.is_complete == true' \
     cargo run --quiet -- sign-pending \
         --secret-key "$SSH_KEY_2" -u "$backend" --password "$key_password" \
-        "$RELEASE_INDEX_ID"
+        $RELEASE_SIGN_ARGS
 
 assert_release_index_active "$RELEASE_VERSION"
 

--- a/tests/e2e_tests/ssh_keys_flow_local.sh
+++ b/tests/e2e_tests/ssh_keys_flow_local.sh
@@ -296,7 +296,7 @@ assert_release_index_exists "$RELEASE_VERSION"
 assert_release_index_pending "$RELEASE_VERSION"
 assert_last_commit_contains "$INDEX_FILE"
 
-RELEASE_SIGN_ARGS=$(release_index_sign_args "$RELEASE_VERSION" "$SSH_KEY_1" "$backend" "$key_password")
+RELEASE_SIGN_ARGS=$(pending_sign_args "$INDEX_FILE" "$SSH_KEY_1" "$backend" "$key_password")
 
 ################################################################################
 section "Sign release index with both SSH keys"


### PR DESCRIPTION
When generating a signers file, its digest (sha512) is printed. 
When signing a file, the digest must now be passed by the user.  Either on the command line, or in the interactive selection list where the digest is displayed for validation.